### PR TITLE
Install Claude skills + ship simple-roguelike on GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,74 @@
+name: Deploy games to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "simple-roguelike/**"
+      - ".github/workflows/deploy.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: simple-roguelike/package-lock.json
+
+      - name: Install deps (simple-roguelike)
+        working-directory: simple-roguelike
+        run: npm ci
+
+      - name: Run tests (simple-roguelike)
+        working-directory: simple-roguelike
+        run: npm test
+
+      - name: Build (simple-roguelike)
+        working-directory: simple-roguelike
+        run: npm run build
+
+      - name: Assemble Pages artifact
+        run: |
+          mkdir -p _site/simple-roguelike
+          cp -r simple-roguelike/dist/* _site/simple-roguelike/
+          cat > _site/index.html <<'HTML'
+          <!doctype html>
+          <meta charset="utf-8">
+          <title>2D game playground</title>
+          <meta http-equiv="refresh" content="0; url=./simple-roguelike/">
+          <link rel="canonical" href="./simple-roguelike/">
+          <style>
+            body { font-family: ui-monospace, monospace; background: #0d0d14; color: #d6d6e0; padding: 24px; }
+            a { color: #f0b850; }
+          </style>
+          <h1>2D game playground</h1>
+          <p><a href="./simple-roguelike/">Play simple-roguelike</a></p>
+          HTML
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # 2D-game-playground
+
+A folder of small browser games, each in its own subfolder.
+
+## Games
+
+| Folder | Description | Play |
+|---|---|---|
+| [`simple-roguelike/`](./simple-roguelike) | Tiny turn-based roguelike — FOV, dungeon gen, bump-to-attack, goblins, stairs | [Play](https://zerolr.github.io/2D-game-playground/simple-roguelike/) |
+
+## Development
+
+Each game is an independent Vite project. For example:
+
+```sh
+cd simple-roguelike
+npm ci
+npm run dev       # local dev server
+npm test          # vitest suite
+npm run build     # production build into dist/
+```
+
+## Deployment
+
+GitHub Pages is wired up via [`.github/workflows/deploy.yml`](./.github/workflows/deploy.yml). Any push to `main` that touches a game folder rebuilds and publishes the site.
+
+The first time this runs, enable Pages in **Settings → Pages → Source = GitHub Actions**.
+
+Each game is served under `https://zerolr.github.io/2D-game-playground/<game-folder>/`. The root `/2D-game-playground/` redirects to `simple-roguelike` for now; swap in a real landing page once there are multiple games.
+
+## Claude skills
+
+`.claude/skills/` contains four skills from [`zeroLR/skills`](https://github.com/zeroLR/skills) that auto-trigger while working on these games: `game-scaffold`, `game-loop`, `game-systems`, `game-perf`.

--- a/simple-roguelike/.gitignore
+++ b/simple-roguelike/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.DS_Store
+*.log

--- a/simple-roguelike/README.md
+++ b/simple-roguelike/README.md
@@ -1,0 +1,49 @@
+# simple-roguelike
+
+A small turn-based roguelike built with Vite + TypeScript + PixiJS + rot-js. Deployed to GitHub Pages at https://zerolr.github.io/2D-game-playground/simple-roguelike/ by the repo-level workflow.
+
+## Gameplay
+
+- Move with arrow keys or `hjkl` (diagonals: `yubn`).
+- `.` waits a turn. `r` restarts with a new seed.
+- Walk into enemies to bump-attack them.
+- Reach the stairs `>` to escape the dungeon.
+
+Append `?seed=123` to the URL to play a reproducible run.
+
+## Structure
+
+```
+src/
+├── main.ts            # boot: PIXI app, input handler, render loop
+├── game/
+│   ├── rng.ts         # seeded mulberry32
+│   ├── world.ts       # bag-of-components ECS
+│   ├── turn.ts        # pattern-3 turn loop (player → enemies → FOV → render)
+│   ├── map/           # tiles, TileMap, Digger-based generate + BFS check
+│   ├── systems/       # input, movement, combat, fov, ai
+│   └── entities/      # spawnPlayer, spawnGoblin
+├── render/
+│   ├── textures.ts    # procedural 16×16 sprites via PIXI.Graphics
+│   └── stage.ts       # PIXI containers for tile + entity layers
+└── ui/hud.ts          # plain DOM status + message log
+tests/                 # vitest: rng, generate, fov
+```
+
+## Scripts
+
+```sh
+npm ci           # install deps
+npm run dev      # Vite dev server with HMR
+npm test         # vitest (16 tests)
+npm run build    # typecheck + production bundle into dist/
+npm run preview  # serve dist/ at the Pages base path
+```
+
+## Design notes
+
+- Procedurally-drawn sprites (no external asset file) — edit `src/render/textures.ts` to retheme.
+- Turn-based instant loop (game-loop pattern #3) — the sim only advances on a valid player action.
+- Determinism: every random call routes through a single seeded RNG (`src/game/rng.ts`); the seed is logged at boot and displayed in the HUD.
+- FOV uses rot-js's `PreciseShadowcasting`; tiles render in three states (visible / seen / unseen).
+- Enemy AI uses `ROT.Path.AStar` — goblins stand still until they've seen the player once.

--- a/simple-roguelike/index.html
+++ b/simple-roguelike/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>simple-roguelike</title>
+  </head>
+  <body>
+    <main id="app">
+      <h1>simple-roguelike</h1>
+      <div id="game"></div>
+      <div id="hud">
+        <div id="status">HP: - · Seed: -</div>
+        <ul id="log"></ul>
+      </div>
+      <p class="help">
+        Arrows / <kbd>hjkl</kbd> move · <kbd>.</kbd> wait · <kbd>r</kbd> restart · bump enemies to attack
+      </p>
+    </main>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/simple-roguelike/package-lock.json
+++ b/simple-roguelike/package-lock.json
@@ -1,0 +1,2663 @@
+{
+  "name": "simple-roguelike",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "simple-roguelike",
+      "version": "0.1.0",
+      "dependencies": {
+        "pixi.js": "^8.6.6",
+        "rot-js": "^2.2.1"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.2",
+        "typescript": "^5.7.2",
+        "vite": "^6.0.7",
+        "vitest": "^2.1.8"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@pixi/colord": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
+      "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/earcut": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-3.0.0.tgz",
+      "integrity": "sha512-k/9fOUGO39yd2sCjrbAJvGDEQvRwRnQIZlBz43roGwUZo5SHAmyVvSFyaVVZkicRVCaDXPKlbxrUcBuJoSWunQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.69",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
+      "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gifuct-js": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/gifuct-js/-/gifuct-js-2.1.2.tgz",
+      "integrity": "sha512-rI2asw77u0mGgwhV3qA+OEgYqaDn5UNqgs+Bx0FGwSpuqfYn+Ir6RQY5ENNQ8SbIiG/m5gVa7CD5RriO4f4Lsg==",
+      "license": "MIT",
+      "dependencies": {
+        "js-binary-schema-parser": "^2.0.3"
+      }
+    },
+    "node_modules/ismobilejs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
+      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
+      "license": "MIT"
+    },
+    "node_modules/js-binary-schema-parser": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/js-binary-schema-parser/-/js-binary-schema-parser-2.0.3.tgz",
+      "integrity": "sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==",
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pixi.js": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.18.0.tgz",
+      "integrity": "sha512-zSA1SH8NiBkgyPeg8bWjdddBMOlXHE5ZNS5yoi3e/acAcBwLRM72hIS6IqVjvlTTBGOBFq72mRYtzt/haxL9Tw==",
+      "license": "MIT",
+      "workspaces": [
+        "examples",
+        "playground"
+      ],
+      "dependencies": {
+        "@pixi/colord": "^2.9.6",
+        "@types/earcut": "^3.0.0",
+        "@webgpu/types": "^0.1.69",
+        "@xmldom/xmldom": "^0.8.12",
+        "earcut": "^3.0.2",
+        "eventemitter3": "^5.0.1",
+        "gifuct-js": "^2.1.2",
+        "ismobilejs": "^1.1.1",
+        "parse-svg-path": "^0.1.2",
+        "tiny-lru": "^11.4.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rot-js": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/rot-js/-/rot-js-2.2.1.tgz",
+      "integrity": "sha512-lItXH31vj4ebdypayCx9dh98qPr57E7jGW2lVMKxtBHooU3xpGRtLS8kdJIni232tvPJ8Sl0+aqXZj8c6W0MGw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tiny-lru": {
+      "version": "11.4.7",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-11.4.7.tgz",
+      "integrity": "sha512-w/Te7uMUVeH0CR8vZIjr+XiN41V+30lkDdK+NRIDCUYKKuL9VcmaUEmaPISuwGhLlrTGh5yu18lENtR9axSxYw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/simple-roguelike/package.json
+++ b/simple-roguelike/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "simple-roguelike",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "pixi.js": "^8.6.6",
+    "rot-js": "^2.2.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "typescript": "^5.7.2",
+    "vite": "^6.0.7",
+    "vitest": "^2.1.8"
+  }
+}

--- a/simple-roguelike/src/game/entities/factories.ts
+++ b/simple-roguelike/src/game/entities/factories.ts
@@ -1,0 +1,25 @@
+import type { EntityId, World } from "../world";
+
+export function spawnPlayer(world: World, x: number, y: number): EntityId {
+  return world.create({
+    position: { x, y },
+    renderable: { sprite: "player" },
+    blocker: true,
+    health: { hp: 20, max: 20 },
+    combat: { damageDice: [1, 6] },
+    name: "you",
+    player: true,
+  });
+}
+
+export function spawnGoblin(world: World, x: number, y: number): EntityId {
+  return world.create({
+    position: { x, y },
+    renderable: { sprite: "goblin" },
+    blocker: true,
+    health: { hp: 5, max: 5 },
+    combat: { damageDice: [1, 3] },
+    ai: { kind: "hostile", hasSeenPlayer: false },
+    name: "the goblin",
+  });
+}

--- a/simple-roguelike/src/game/map/generate.ts
+++ b/simple-roguelike/src/game/map/generate.ts
@@ -1,0 +1,106 @@
+import * as ROT from "rot-js";
+
+import type { Rng } from "../rng";
+import { Tile } from "./tiles";
+import { TileMap } from "./tilemap";
+
+export interface GeneratedLevel {
+  map: TileMap;
+  /** Center of room #0 — where the player spawns. */
+  spawn: { x: number; y: number };
+  /** Furthest room (by BFS path length) from the spawn. */
+  stairs: { x: number; y: number };
+  /** Centers of all rooms — handy for spawning enemies. */
+  roomCenters: { x: number; y: number }[];
+}
+
+// generateLevel body is adapted from .claude/skills/game-systems/SKILL.md:167-175,
+// plus the connectivity BFS guard the same skill warns about on line 177.
+export function generateLevel(rng: Rng, width: number, height: number): GeneratedLevel {
+  // Up to 20 attempts; each time, reseed rot-js from our RNG so the result
+  // stays deterministic for a given game seed.
+  for (let attempt = 0; attempt < 20; attempt++) {
+    ROT.RNG.setSeed(Math.floor(rng() * 2 ** 31));
+    const digger = new ROT.Map.Digger(width, height, {
+      roomWidth: [4, 8],
+      roomHeight: [3, 6],
+      dugPercentage: 0.25,
+    });
+    const map = new TileMap(width, height, Tile.Wall);
+    digger.create((x, y, wall) => {
+      map.set(x, y, wall ? Tile.Wall : Tile.Floor);
+    });
+
+    const rooms = digger.getRooms();
+    if (rooms.length < 3) continue;
+
+    const roomCenters = rooms.map((r) => {
+      const [x, y] = r.getCenter();
+      return { x, y };
+    });
+    const spawn = roomCenters[0];
+
+    const dist = bfsDistances(map, spawn);
+    if (!allFloorReachable(map, dist)) continue;
+
+    // Stairs go in the room whose center is farthest (by path length) from spawn.
+    let stairs = roomCenters[0];
+    let best = -1;
+    for (const c of roomCenters) {
+      const d = dist[c.y * map.width + c.x];
+      if (d > best) {
+        best = d;
+        stairs = c;
+      }
+    }
+    map.set(stairs.x, stairs.y, Tile.Stairs);
+
+    return { map, spawn, stairs, roomCenters };
+  }
+
+  throw new Error("generateLevel: could not produce a connected level after 20 attempts");
+}
+
+/**
+ * Breadth-first search over floor tiles starting from `origin`.
+ * Returns an `Int32Array` the size of the map; unreachable cells stay -1.
+ */
+function bfsDistances(map: TileMap, origin: { x: number; y: number }): Int32Array {
+  const dist = new Int32Array(map.width * map.height).fill(-1);
+  const queue: number[] = [];
+  const idx = (x: number, y: number) => y * map.width + x;
+
+  dist[idx(origin.x, origin.y)] = 0;
+  queue.push(origin.x, origin.y);
+
+  while (queue.length > 0) {
+    const x = queue.shift()!;
+    const y = queue.shift()!;
+    const d = dist[idx(x, y)];
+    for (const [dx, dy] of NEIGHBOURS) {
+      const nx = x + dx;
+      const ny = y + dy;
+      if (!map.inBounds(nx, ny)) continue;
+      if (map.info(nx, ny).blocksMove) continue;
+      if (dist[idx(nx, ny)] !== -1) continue;
+      dist[idx(nx, ny)] = d + 1;
+      queue.push(nx, ny);
+    }
+  }
+  return dist;
+}
+
+function allFloorReachable(map: TileMap, dist: Int32Array): boolean {
+  for (const [x, y, t] of map.cells()) {
+    if (t === Tile.Wall) continue;
+    if (dist[y * map.width + x] === -1) return false;
+  }
+  return true;
+}
+
+const NEIGHBOURS: readonly [number, number][] = [
+  [0, -1],
+  [0, 1],
+  [-1, 0],
+  [1, 0],
+];

--- a/simple-roguelike/src/game/map/tilemap.ts
+++ b/simple-roguelike/src/game/map/tilemap.ts
@@ -1,0 +1,43 @@
+import { Tile, TILE_INFO, type TileInfo } from "./tiles";
+
+/**
+ * A dense w×h grid of tiles. Row-major (`y * width + x`).
+ * Cheap to clone, cheap to serialize, cheap to iterate.
+ */
+export class TileMap {
+  readonly width: number;
+  readonly height: number;
+  private readonly data: Uint8Array;
+
+  constructor(width: number, height: number, fill: Tile = Tile.Wall) {
+    this.width = width;
+    this.height = height;
+    this.data = new Uint8Array(width * height);
+    if (fill !== Tile.Wall) this.data.fill(fill);
+  }
+
+  inBounds(x: number, y: number): boolean {
+    return x >= 0 && y >= 0 && x < this.width && y < this.height;
+  }
+
+  at(x: number, y: number): Tile {
+    return this.data[y * this.width + x] as Tile;
+  }
+
+  info(x: number, y: number): TileInfo {
+    return TILE_INFO[this.at(x, y)];
+  }
+
+  set(x: number, y: number, t: Tile): void {
+    this.data[y * this.width + x] = t;
+  }
+
+  /** Iterate every (x, y, tile). */
+  *cells(): Generator<[number, number, Tile]> {
+    for (let y = 0; y < this.height; y++) {
+      for (let x = 0; x < this.width; x++) {
+        yield [x, y, this.data[y * this.width + x] as Tile];
+      }
+    }
+  }
+}

--- a/simple-roguelike/src/game/map/tiles.ts
+++ b/simple-roguelike/src/game/map/tiles.ts
@@ -1,0 +1,20 @@
+// Tile kinds and their movement/sight properties.
+// Keep this table tiny — a roguelike rarely needs more than a handful.
+
+export enum Tile {
+  Wall = 0,
+  Floor = 1,
+  Stairs = 2,
+}
+
+export interface TileInfo {
+  blocksMove: boolean;
+  blocksSight: boolean;
+  name: string;
+}
+
+export const TILE_INFO: Record<Tile, TileInfo> = {
+  [Tile.Wall]:   { blocksMove: true,  blocksSight: true,  name: "wall" },
+  [Tile.Floor]:  { blocksMove: false, blocksSight: false, name: "floor" },
+  [Tile.Stairs]: { blocksMove: false, blocksSight: false, name: "stairs" },
+};

--- a/simple-roguelike/src/game/rng.ts
+++ b/simple-roguelike/src/game/rng.ts
@@ -1,0 +1,42 @@
+// Seeded RNG. Mulberry32 — from game-scaffold skill.
+// Every random decision in the game MUST go through this so that a given seed
+// produces an identical run. That is how roguelike bugs become reproducible.
+
+export type Rng = () => number;
+
+export function createRng(seed: number): Rng {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Pick the seed from `?seed=123` in the URL, or generate a fresh one from
+ * `Date.now()` if absent / invalid. Returns a positive 32-bit integer.
+ */
+export function pickSeed(search = typeof location !== "undefined" ? location.search : ""): number {
+  const params = new URLSearchParams(search);
+  const raw = params.get("seed");
+  if (raw !== null) {
+    const n = Number.parseInt(raw, 10);
+    if (Number.isFinite(n)) return n >>> 0;
+  }
+  return (Date.now() & 0x7fffffff) >>> 0;
+}
+
+/** Integer in [lo, hi] inclusive. */
+export function randInt(rng: Rng, lo: number, hi: number): number {
+  return lo + Math.floor(rng() * (hi - lo + 1));
+}
+
+/** Roll `n` dice of `sides` sides (e.g. `roll(rng, 1, 6)` = 1d6). */
+export function roll(rng: Rng, n: number, sides: number): number {
+  let sum = 0;
+  for (let i = 0; i < n; i++) sum += randInt(rng, 1, sides);
+  return sum;
+}

--- a/simple-roguelike/src/game/systems/ai.ts
+++ b/simple-roguelike/src/game/systems/ai.ts
@@ -1,0 +1,74 @@
+import * as ROT from "rot-js";
+
+import type { EntityId, World } from "../world";
+import type { TileMap } from "../map/tilemap";
+import type { Rng } from "../rng";
+import type { Visibility } from "./fov";
+import { canWalk, tryMove } from "./movement";
+import type { MessageLog } from "../../ui/hud";
+
+/**
+ * Step every hostile one tile closer to the player via A*. Enemies who have
+ * never seen the player stay put. Once they've been in the player's FOV even
+ * once, `hasSeenPlayer` flips true and they keep hunting.
+ *
+ * Uses `ROT.Path.AStar` with a passability callback that treats occupied
+ * enemy tiles as blockers — except the goal tile (the player) so A* can
+ * always land on it.
+ */
+export function enemiesAct(
+  world: World,
+  map: TileMap,
+  vis: Visibility,
+  rng: Rng,
+  log: MessageLog,
+): void {
+  const p = world.player();
+  if (!p) return;
+  const [playerId, playerC] = p;
+  if (!playerC.position) return;
+  const pos = playerC.position;
+
+  // Snapshot enemy ids up front — we may mutate the world during iteration.
+  const enemies: EntityId[] = [];
+  for (const [id] of world.with("ai", "position")) {
+    if (id === playerId) continue;
+    enemies.push(id);
+  }
+
+  for (const id of enemies) {
+    const c = world.get(id);
+    if (!c?.ai || !c.position) continue;
+
+    const i = c.position.y * map.width + c.position.x;
+    const canSeePlayer = vis.visible.has(i);
+    if (canSeePlayer) c.ai.hasSeenPlayer = true;
+    if (!c.ai.hasSeenPlayer) continue;
+
+    const astar = new ROT.Path.AStar(pos.x, pos.y, (x: number, y: number) => {
+      if (!map.inBounds(x, y)) return false;
+      if (map.info(x, y).blocksMove) return false;
+      // The goal tile (player) is always "passable" so A* can reach it.
+      if (x === pos.x && y === pos.y) return true;
+      // Any other blocker (enemies, walls) prevents planning through.
+      return world.blockerAt(x, y) === undefined;
+    });
+
+    const path: Array<[number, number]> = [];
+    astar.compute(c.position.x, c.position.y, (x, y) => {
+      path.push([x, y]);
+    });
+
+    // path[0] is the enemy's own tile; path[1] is the next step.
+    if (path.length < 2) continue;
+    const [nx, ny] = path[1];
+    const dx = nx - c.position.x;
+    const dy = ny - c.position.y;
+
+    // If the next step is blocked right now (shouldn't happen since we just
+    // ran A* with the same predicate, but defensive), fall back to waiting.
+    if (!canWalk(world, map, nx, ny) && (nx !== pos.x || ny !== pos.y)) continue;
+
+    tryMove(world, map, id, dx, dy, rng, log);
+  }
+}

--- a/simple-roguelike/src/game/systems/combat.ts
+++ b/simple-roguelike/src/game/systems/combat.ts
@@ -1,0 +1,42 @@
+import type { EntityId, World } from "../world";
+import type { Rng } from "../rng";
+import { roll } from "../rng";
+import type { MessageLog } from "../../ui/hud";
+
+/**
+ * Resolve an attack from `attacker` to `target`. Rolls damage, applies it,
+ * pushes a message, and removes the target if it died.
+ *
+ * Returns `true` if the target died as a result.
+ */
+export function attack(
+  world: World,
+  attacker: EntityId,
+  target: EntityId,
+  rng: Rng,
+  log: MessageLog,
+): boolean {
+  const atkC = world.get(attacker);
+  const tgtC = world.get(target);
+  if (!atkC || !tgtC || !tgtC.health || !atkC.combat) return false;
+
+  const [n, sides] = atkC.combat.damageDice;
+  const dmg = roll(rng, n, sides);
+  tgtC.health.hp = Math.max(0, tgtC.health.hp - dmg);
+
+  const atkName = atkC.name ?? "something";
+  const tgtName = tgtC.name ?? "something";
+  log.push(`${capitalize(atkName)} hits ${tgtName} for ${dmg}.`);
+
+  if (tgtC.health.hp <= 0) {
+    log.push(`${capitalize(tgtName)} dies.`);
+    // Don't remove the player — main.ts handles the death overlay.
+    if (!tgtC.player) world.remove(target);
+    return true;
+  }
+  return false;
+}
+
+function capitalize(s: string): string {
+  return s.length === 0 ? s : s[0].toUpperCase() + s.slice(1);
+}

--- a/simple-roguelike/src/game/systems/fov.ts
+++ b/simple-roguelike/src/game/systems/fov.ts
@@ -1,0 +1,41 @@
+import * as ROT from "rot-js";
+import type { TileMap } from "../map/tilemap";
+
+/**
+ * Field-of-view state. `visible` is the set of tiles currently lit; `seen` is
+ * the accumulated "memory" set of every tile the player has ever seen.
+ *
+ * Both stores use `y * width + x` integer indices for cheap Set operations.
+ */
+export interface Visibility {
+  visible: Set<number>;
+  seen: Set<number>;
+}
+
+export function newVisibility(): Visibility {
+  return { visible: new Set(), seen: new Set() };
+}
+
+/**
+ * Recompute visibility for the player. Adapted from game-systems skill
+ * (.claude/skills/game-systems/SKILL.md:140-149) but using integer indices
+ * instead of string keys so the hot set lookups stay cheap.
+ */
+export function recomputeFov(
+  map: TileMap,
+  from: { x: number; y: number },
+  radius: number,
+  vis: Visibility,
+): void {
+  vis.visible.clear();
+  const fov = new ROT.FOV.PreciseShadowcasting((x, y) => {
+    if (!map.inBounds(x, y)) return false;
+    return !map.info(x, y).blocksSight;
+  });
+  fov.compute(from.x, from.y, radius, (x, y) => {
+    if (!map.inBounds(x, y)) return;
+    const i = y * map.width + x;
+    vis.visible.add(i);
+    vis.seen.add(i);
+  });
+}

--- a/simple-roguelike/src/game/systems/input.ts
+++ b/simple-roguelike/src/game/systems/input.ts
@@ -1,0 +1,32 @@
+// Key-to-Action mapping. Lifted directly from game-systems skill
+// (.claude/skills/game-systems/SKILL.md:93-113) and trimmed to the v1 actions.
+
+export type Action =
+  | { type: "move"; dx: -1 | 0 | 1; dy: -1 | 0 | 1 }
+  | { type: "wait" }
+  | { type: "restart" };
+
+const bindings: Record<string, Action> = {
+  // Arrow keys
+  ArrowUp:    { type: "move", dx: 0, dy: -1 },
+  ArrowDown:  { type: "move", dx: 0, dy: 1 },
+  ArrowLeft:  { type: "move", dx: -1, dy: 0 },
+  ArrowRight: { type: "move", dx: 1, dy: 0 },
+  // Vi keys
+  h:          { type: "move", dx: -1, dy: 0 },
+  j:          { type: "move", dx: 0, dy: 1 },
+  k:          { type: "move", dx: 0, dy: -1 },
+  l:          { type: "move", dx: 1, dy: 0 },
+  // Diagonals (vi)
+  y:          { type: "move", dx: -1, dy: -1 },
+  u:          { type: "move", dx: 1, dy: -1 },
+  b:          { type: "move", dx: -1, dy: 1 },
+  n:          { type: "move", dx: 1, dy: 1 },
+  // Wait / restart
+  ".":        { type: "wait" },
+  r:          { type: "restart" },
+};
+
+export function keyToAction(e: KeyboardEvent): Action | null {
+  return bindings[e.key] ?? null;
+}

--- a/simple-roguelike/src/game/systems/movement.ts
+++ b/simple-roguelike/src/game/systems/movement.ts
@@ -1,0 +1,54 @@
+import type { EntityId, World } from "../world";
+import type { TileMap } from "../map/tilemap";
+import type { Rng } from "../rng";
+import { attack } from "./combat";
+import type { MessageLog } from "../../ui/hud";
+
+/**
+ * Can the given tile be walked into? Adapted from game-systems skill
+ * (.claude/skills/game-systems/SKILL.md:122-129).
+ */
+export function canWalk(world: World, map: TileMap, x: number, y: number): boolean {
+  if (!map.inBounds(x, y)) return false;
+  if (map.info(x, y).blocksMove) return false;
+  if (world.blockerAt(x, y) !== undefined) return false;
+  return true;
+}
+
+export type MoveResult =
+  | { kind: "moved"; to: { x: number; y: number } }
+  | { kind: "attacked"; target: EntityId; killed: boolean }
+  | { kind: "blocked" };
+
+/**
+ * Try to move an entity by (dx, dy). On a wall or out-of-bounds this is a
+ * no-op. If another blocker is in the way, attempt a bump-to-attack.
+ */
+export function tryMove(
+  world: World,
+  map: TileMap,
+  id: EntityId,
+  dx: number,
+  dy: number,
+  rng: Rng,
+  log: MessageLog,
+): MoveResult {
+  const c = world.get(id);
+  if (!c?.position) return { kind: "blocked" };
+  const nx = c.position.x + dx;
+  const ny = c.position.y + dy;
+
+  if (!map.inBounds(nx, ny) || map.info(nx, ny).blocksMove) {
+    return { kind: "blocked" };
+  }
+
+  const blocker = world.blockerAt(nx, ny);
+  if (blocker !== undefined && blocker !== id) {
+    const killed = attack(world, id, blocker, rng, log);
+    return { kind: "attacked", target: blocker, killed };
+  }
+
+  c.position.x = nx;
+  c.position.y = ny;
+  return { kind: "moved", to: { x: nx, y: ny } };
+}

--- a/simple-roguelike/src/game/turn.ts
+++ b/simple-roguelike/src/game/turn.ts
@@ -1,0 +1,71 @@
+// Turn-based instant loop (game-loop pattern #3).
+// The player's action drives everything: we accept input, resolve it, let
+// every enemy take one step, recompute FOV, then return so the caller can
+// re-render. Nothing ticks in the background.
+
+import type { Rng } from "./rng";
+import type { World } from "./world";
+import type { TileMap } from "./map/tilemap";
+import type { Action } from "./systems/input";
+import type { Visibility } from "./systems/fov";
+import type { MessageLog } from "../ui/hud";
+import { recomputeFov } from "./systems/fov";
+import { tryMove } from "./systems/movement";
+import { enemiesAct } from "./systems/ai";
+import { Tile } from "./map/tiles";
+
+export interface TurnContext {
+  world: World;
+  map: TileMap;
+  vis: Visibility;
+  rng: Rng;
+  log: MessageLog;
+  fovRadius: number;
+}
+
+export type TurnOutcome = "ongoing" | "dead" | "escaped" | "noop";
+
+/**
+ * Apply one player action and advance the world one turn. Returns a high-level
+ * outcome so `main.ts` knows whether to swap into a game-over state.
+ */
+export function runTurn(ctx: TurnContext, action: Action): TurnOutcome {
+  if (action.type === "restart") return "noop"; // handled at the main-loop level
+  const p = ctx.world.player();
+  if (!p) return "dead";
+  const [playerId, playerC] = p;
+  if (!playerC.position || !playerC.health) return "dead";
+
+  // 1. Player acts.
+  let playerDidSomething = false;
+  if (action.type === "move") {
+    const res = tryMove(ctx.world, ctx.map, playerId, action.dx, action.dy, ctx.rng, ctx.log);
+    if (res.kind !== "blocked") playerDidSomething = true;
+  } else if (action.type === "wait") {
+    playerDidSomething = true;
+  }
+
+  if (!playerDidSomething) return "ongoing";
+
+  // 2. Did the player just step onto the stairs?
+  const { x, y } = playerC.position;
+  if (ctx.map.at(x, y) === Tile.Stairs) {
+    ctx.log.push("You descend the stairs. Freedom!");
+    return "escaped";
+  }
+
+  // 3. Did the player die to their own action? (Can't in v1, but keep the
+  //    guard so movement → future traps behaves correctly.)
+  if (playerC.health.hp <= 0) return "dead";
+
+  // 4. Enemies act.
+  enemiesAct(ctx.world, ctx.map, ctx.vis, ctx.rng, ctx.log);
+
+  // 5. Did the player die from an enemy bump?
+  if (playerC.health.hp <= 0) return "dead";
+
+  // 6. Recompute FOV from the player's new position.
+  recomputeFov(ctx.map, playerC.position, ctx.fovRadius, ctx.vis);
+
+  return "ongoing";
+}

--- a/simple-roguelike/src/game/world.ts
+++ b/simple-roguelike/src/game/world.ts
@@ -1,0 +1,72 @@
+// Bag-of-components ECS, directly from the game-systems skill
+// (.claude/skills/game-systems/SKILL.md:19-51).
+//
+// Systems are pure functions that iterate via `World.with(...keys)`. Easy to
+// test, easy to serialize — the component map is just plain data.
+
+export type EntityId = number;
+
+/** Identifies which sprite this entity uses in the render layer. */
+export type SpriteKey = "player" | "goblin";
+
+export interface Components {
+  position?: { x: number; y: number };
+  renderable?: { sprite: SpriteKey };
+  blocker?: true;
+  health?: { hp: number; max: number };
+  ai?: { kind: "hostile"; hasSeenPlayer: boolean };
+  combat?: { damageDice: [number, number] }; // [n, sides] — e.g. [1, 6] for 1d6
+  name?: string;
+  /** Tag for the one player entity — systems read this to find "the player". */
+  player?: true;
+}
+
+export class World {
+  private next: EntityId = 1;
+  readonly entities = new Map<EntityId, Components>();
+
+  create(c: Components): EntityId {
+    const id = this.next++;
+    this.entities.set(id, c);
+    return id;
+  }
+
+  remove(id: EntityId): void {
+    this.entities.delete(id);
+  }
+
+  get(id: EntityId): Components | undefined {
+    return this.entities.get(id);
+  }
+
+  clear(): void {
+    this.entities.clear();
+    this.next = 1;
+  }
+
+  /** Find the single player entity, or undefined if none. */
+  player(): [EntityId, Components] | undefined {
+    for (const [id, c] of this.entities) {
+      if (c.player) return [id, c];
+    }
+    return undefined;
+  }
+
+  /** Iterate entities that have *all* of the given component keys. */
+  *with<K extends keyof Components>(
+    ...keys: K[]
+  ): Generator<[EntityId, Required<Pick<Components, K>> & Components]> {
+    outer: for (const [id, c] of this.entities) {
+      for (const k of keys) if (c[k] === undefined) continue outer;
+      yield [id, c as Required<Pick<Components, K>> & Components];
+    }
+  }
+
+  /** Return the entity (if any) with a `blocker` at the given tile. */
+  blockerAt(x: number, y: number): EntityId | undefined {
+    for (const [id, c] of this.with("position", "blocker")) {
+      if (c.position.x === x && c.position.y === y) return id;
+    }
+    return undefined;
+  }
+}

--- a/simple-roguelike/src/main.ts
+++ b/simple-roguelike/src/main.ts
@@ -1,0 +1,138 @@
+import "./style.css";
+import { Application } from "pixi.js";
+
+import { createRng, pickSeed } from "./game/rng";
+import { generateLevel } from "./game/map/generate";
+import { World } from "./game/world";
+import { spawnGoblin, spawnPlayer } from "./game/entities/factories";
+import { keyToAction } from "./game/systems/input";
+import { newVisibility, recomputeFov } from "./game/systems/fov";
+import { runTurn, type TurnOutcome } from "./game/turn";
+import { Hud, MessageLog } from "./ui/hud";
+import { buildTextures, TILE_SIZE } from "./render/textures";
+import { Stage } from "./render/stage";
+
+const MAP_W = 48;
+const MAP_H = 28;
+const FOV_RADIUS = 8;
+const ZOOM = 2;
+const GOBLIN_COUNT = 5;
+
+interface Game {
+  seed: number;
+  world: World;
+  map: ReturnType<typeof generateLevel>["map"];
+  vis: ReturnType<typeof newVisibility>;
+  rng: ReturnType<typeof createRng>;
+  log: MessageLog;
+  status: "alive" | "dead" | "escaped";
+}
+
+async function main(): Promise<void> {
+  const app = new Application();
+  await app.init({
+    width: MAP_W * TILE_SIZE * ZOOM,
+    height: MAP_H * TILE_SIZE * ZOOM,
+    background: "#000000",
+    antialias: false,
+    roundPixels: true,
+    resolution: 1,
+    autoDensity: true,
+  });
+
+  const gameRoot = document.getElementById("game");
+  if (!gameRoot) throw new Error("Missing #game host element");
+  gameRoot.appendChild(app.canvas);
+
+  const statusEl = document.getElementById("status");
+  const logEl = document.getElementById("log");
+  if (!statusEl || !logEl) throw new Error("Missing HUD elements");
+  const hud = new Hud(statusEl, logEl);
+
+  const textures = buildTextures(app);
+  const stage = new Stage(textures);
+  stage.root.scale.set(ZOOM);
+  app.stage.addChild(stage.root);
+
+  // Everything that depends on the seed lives in `game`. Restart rebuilds it.
+  let game = newGame(pickSeed(), stage);
+  render(game, stage, hud);
+
+  window.addEventListener("keydown", (e) => {
+    const action = keyToAction(e);
+    if (!action) return;
+    e.preventDefault();
+
+    if (action.type === "restart") {
+      // New seed — show it in the HUD and console like the skill requests.
+      const next = (game.seed + 1) >>> 0;
+      game = newGame(next, stage);
+      render(game, stage, hud);
+      return;
+    }
+
+    // Block further actions once the game is over.
+    if (game.status !== "alive") return;
+
+    const outcome: TurnOutcome = runTurn(
+      {
+        world: game.world,
+        map: game.map,
+        vis: game.vis,
+        rng: game.rng,
+        log: game.log,
+        fovRadius: FOV_RADIUS,
+      },
+      action,
+    );
+
+    if (outcome === "dead") game.status = "dead";
+    else if (outcome === "escaped") game.status = "escaped";
+
+    render(game, stage, hud);
+  });
+}
+
+function newGame(seed: number, stage: Stage): Game {
+  console.log(`[simple-roguelike] seed=${seed}`);
+  const rng = createRng(seed);
+  const world = new World();
+  const { map, spawn, roomCenters } = generateLevel(rng, MAP_W, MAP_H);
+
+  spawnPlayer(world, spawn.x, spawn.y);
+
+  // Drop goblins in the rooms farthest from the player, up to GOBLIN_COUNT.
+  const enemyRooms = roomCenters.slice(1, GOBLIN_COUNT + 1);
+  for (const c of enemyRooms) spawnGoblin(world, c.x, c.y);
+
+  const vis = newVisibility();
+  recomputeFov(map, spawn, FOV_RADIUS, vis);
+
+  const log = new MessageLog();
+  log.push(`You awaken in an unfamiliar dungeon. (seed ${seed})`);
+
+  stage.rebuild(map);
+
+  return { seed, world, map, vis, rng, log, status: "alive" };
+}
+
+function render(game: Game, stage: Stage, hud: Hud): void {
+  stage.redraw(game.world, game.vis);
+  const player = game.world.player();
+  const health = player?.[1].health;
+  hud.render(
+    {
+      hp: health?.hp ?? 0,
+      maxHp: health?.max ?? 0,
+      seed: game.seed,
+      status: game.status,
+    },
+    game.log,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  const el = document.getElementById("status");
+  if (el) el.textContent = `Error: ${(err as Error).message}`;
+});

--- a/simple-roguelike/src/render/stage.ts
+++ b/simple-roguelike/src/render/stage.ts
@@ -1,0 +1,85 @@
+import { Container, Sprite } from "pixi.js";
+
+import type { World } from "../game/world";
+import type { TileMap } from "../game/map/tilemap";
+import { type Visibility } from "../game/systems/fov";
+import { TILE_SIZE, type TextureBank } from "./textures";
+
+const TINT_VISIBLE = 0xffffff;
+const TINT_SEEN = 0x555566;
+
+/**
+ * Keeps the PIXI display in sync with the authoritative game state.
+ *
+ * Tile sprites are created once per level in `rebuild()`. Per turn, `redraw()`
+ * only updates tints and entity positions — cheap and constant-time.
+ */
+export class Stage {
+  readonly root: Container;
+  private readonly tileLayer: Container;
+  private readonly entityLayer: Container;
+  private readonly textures: TextureBank;
+  private tileSprites: Sprite[] = [];
+  private map: TileMap | null = null;
+
+  constructor(textures: TextureBank) {
+    this.textures = textures;
+    this.root = new Container();
+    this.tileLayer = new Container();
+    this.entityLayer = new Container();
+    this.root.addChild(this.tileLayer);
+    this.root.addChild(this.entityLayer);
+  }
+
+  /** Rebuild all tile sprites for a freshly generated map. */
+  rebuild(map: TileMap): void {
+    this.map = map;
+    this.tileLayer.removeChildren().forEach((c) => c.destroy());
+    this.tileSprites = new Array(map.width * map.height);
+    for (const [x, y, t] of map.cells()) {
+      const spr = new Sprite(this.textures.tiles[t]);
+      spr.x = x * TILE_SIZE;
+      spr.y = y * TILE_SIZE;
+      spr.visible = false; // hidden until FOV reveals it
+      this.tileLayer.addChild(spr);
+      this.tileSprites[y * map.width + x] = spr;
+    }
+  }
+
+  /**
+   * Paint one frame of the current world state. Cheap enough to call on every
+   * player turn — no pooling required at this scale.
+   */
+  redraw(world: World, vis: Visibility): void {
+    const map = this.map;
+    if (!map) return;
+
+    // 1. Tile visibility: visible = bright, seen = dim, unseen = hidden.
+    for (let y = 0; y < map.height; y++) {
+      for (let x = 0; x < map.width; x++) {
+        const i = y * map.width + x;
+        const spr = this.tileSprites[i];
+        if (vis.visible.has(i)) {
+          spr.visible = true;
+          spr.tint = TINT_VISIBLE;
+        } else if (vis.seen.has(i)) {
+          spr.visible = true;
+          spr.tint = TINT_SEEN;
+        } else {
+          spr.visible = false;
+        }
+      }
+    }
+
+    // 2. Entity layer: clear and re-add only the ones currently visible.
+    this.entityLayer.removeChildren();
+    for (const [, c] of world.with("position", "renderable")) {
+      const i = c.position.y * map.width + c.position.x;
+      if (!vis.visible.has(i)) continue;
+      const spr = new Sprite(this.textures.sprites[c.renderable.sprite]);
+      spr.x = c.position.x * TILE_SIZE;
+      spr.y = c.position.y * TILE_SIZE;
+      this.entityLayer.addChild(spr);
+    }
+  }
+}

--- a/simple-roguelike/src/render/textures.ts
+++ b/simple-roguelike/src/render/textures.ts
@@ -1,0 +1,156 @@
+import { Application, Container, Graphics, Rectangle, Texture } from "pixi.js";
+import type { SpriteKey } from "../game/world";
+import { Tile } from "../game/map/tiles";
+
+export const TILE_SIZE = 16;
+
+export type TextureBank = {
+  tiles: Record<Tile, Texture>;
+  sprites: Record<SpriteKey, Texture>;
+};
+
+/**
+ * Build every texture the game uses once at boot, from pure `PIXI.Graphics`.
+ *
+ * No external asset files — each glyph is a few colored rectangles drawn at
+ * integer coordinates, so the result looks pixel-art without shipping a PNG.
+ * Edit these to retheme the game.
+ */
+export function buildTextures(app: Application): TextureBank {
+  return {
+    tiles: {
+      [Tile.Wall]: makeTexture(app, drawWall),
+      [Tile.Floor]: makeTexture(app, drawFloor),
+      [Tile.Stairs]: makeTexture(app, drawStairs),
+    },
+    sprites: {
+      player: makeTexture(app, drawPlayer),
+      goblin: makeTexture(app, drawGoblin),
+    },
+  };
+}
+
+function makeTexture(app: Application, draw: (g: Graphics) => void): Texture {
+  const g = new Graphics();
+  draw(g);
+  // Wrap in a container so the renderer frames against a full 16x16 bound
+  // regardless of what `g` drew. Without this, textures with empty edges get
+  // trimmed and sprites no longer sit flush to the tile grid.
+  const host = new Container();
+  host.addChild(g);
+  const texture = app.renderer.generateTexture({
+    target: host,
+    frame: new Rectangle(0, 0, TILE_SIZE, TILE_SIZE),
+    resolution: 1,
+    antialias: false,
+  });
+  host.destroy({ children: true });
+  return texture;
+}
+
+// ---------- tile glyphs ----------
+
+function drawFloor(g: Graphics): void {
+  g.rect(0, 0, TILE_SIZE, TILE_SIZE).fill(0x1a1a24);
+  // faint stone speckle so empty rooms aren't dead flat
+  for (const [x, y] of [
+    [3, 4],
+    [10, 2],
+    [6, 11],
+    [12, 9],
+    [2, 13],
+  ]) {
+    g.rect(x, y, 1, 1).fill(0x2a2a38);
+  }
+}
+
+function drawWall(g: Graphics): void {
+  // brick base
+  g.rect(0, 0, TILE_SIZE, TILE_SIZE).fill(0x4a4458);
+  // horizontal mortar
+  g.rect(0, 5, TILE_SIZE, 1).fill(0x201d2a);
+  g.rect(0, 11, TILE_SIZE, 1).fill(0x201d2a);
+  // staggered vertical mortar
+  g.rect(7, 0, 1, 5).fill(0x201d2a);
+  g.rect(3, 6, 1, 5).fill(0x201d2a);
+  g.rect(11, 6, 1, 5).fill(0x201d2a);
+  g.rect(7, 12, 1, 4).fill(0x201d2a);
+  // brick highlights
+  g.rect(0, 0, TILE_SIZE, 1).fill(0x6a6278);
+  g.rect(0, 6, TILE_SIZE, 1).fill(0x5a5468);
+}
+
+function drawStairs(g: Graphics): void {
+  drawFloor(g);
+  // descending stairs — lighter as they go down
+  g.rect(2, 4, 12, 3).fill(0x7a6f42);
+  g.rect(2, 7, 12, 3).fill(0x948864);
+  g.rect(2, 10, 12, 3).fill(0xb0a382);
+  g.rect(2, 4, 12, 1).fill(0x3a3420);
+  g.rect(2, 7, 12, 1).fill(0x3a3420);
+  g.rect(2, 10, 12, 1).fill(0x3a3420);
+}
+
+// ---------- entity sprites ----------
+
+function drawPlayer(g: Graphics): void {
+  // transparent background; small heroic figure
+  // head
+  g.rect(6, 2, 4, 4).fill(0xf3d6a7);
+  g.rect(5, 3, 1, 2).fill(0xf3d6a7);
+  g.rect(10, 3, 1, 2).fill(0xf3d6a7);
+  // hair
+  g.rect(6, 1, 4, 1).fill(0x5a3a1a);
+  g.rect(5, 2, 1, 1).fill(0x5a3a1a);
+  g.rect(10, 2, 1, 1).fill(0x5a3a1a);
+  // eyes
+  g.rect(7, 4, 1, 1).fill(0x000000);
+  g.rect(9, 4, 1, 1).fill(0x000000);
+  // body / tunic
+  g.rect(5, 7, 6, 5).fill(0x3a6bd6);
+  g.rect(4, 8, 1, 3).fill(0x3a6bd6); // left sleeve
+  g.rect(11, 8, 1, 3).fill(0x3a6bd6); // right sleeve
+  // belt
+  g.rect(5, 11, 6, 1).fill(0x3a2a14);
+  // legs
+  g.rect(5, 12, 2, 3).fill(0x241a3a);
+  g.rect(9, 12, 2, 3).fill(0x241a3a);
+  // boots
+  g.rect(4, 14, 3, 1).fill(0x1a1020);
+  g.rect(9, 14, 3, 1).fill(0x1a1020);
+  // sword (right hand)
+  g.rect(12, 5, 1, 6).fill(0xdedede);
+  g.rect(11, 11, 3, 1).fill(0x8a5a1a);
+}
+
+function drawGoblin(g: Graphics): void {
+  // head
+  g.rect(5, 2, 6, 5).fill(0x5aa84a);
+  g.rect(4, 3, 1, 3).fill(0x5aa84a); // left ear
+  g.rect(11, 3, 1, 3).fill(0x5aa84a); // right ear
+  // darker brow
+  g.rect(5, 2, 6, 1).fill(0x3a7a2a);
+  // eyes (glowing red)
+  g.rect(6, 4, 1, 1).fill(0xd62828);
+  g.rect(9, 4, 1, 1).fill(0xd62828);
+  // snout / teeth
+  g.rect(7, 5, 2, 1).fill(0x3a5a2a);
+  g.rect(7, 6, 1, 1).fill(0xf0f0d6);
+  g.rect(8, 6, 1, 1).fill(0xf0f0d6);
+  // body
+  g.rect(5, 7, 6, 4).fill(0x4a8838);
+  // loincloth
+  g.rect(5, 11, 6, 1).fill(0x7a4a1a);
+  // arms
+  g.rect(4, 8, 1, 3).fill(0x5aa84a);
+  g.rect(11, 8, 1, 3).fill(0x5aa84a);
+  // legs
+  g.rect(5, 12, 2, 3).fill(0x4a8838);
+  g.rect(9, 12, 2, 3).fill(0x4a8838);
+  // feet
+  g.rect(4, 14, 3, 1).fill(0x241a08);
+  g.rect(9, 14, 3, 1).fill(0x241a08);
+  // club
+  g.rect(3, 5, 1, 5).fill(0x8a5a1a);
+  g.rect(2, 5, 3, 1).fill(0x5a3a14);
+}

--- a/simple-roguelike/src/style.css
+++ b/simple-roguelike/src/style.css
@@ -1,0 +1,94 @@
+:root {
+  color-scheme: dark;
+  --bg: #0d0d14;
+  --fg: #d6d6e0;
+  --accent: #f0b850;
+  --muted: #7a7a8a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  min-height: 100vh;
+}
+
+#app {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+h1 {
+  margin: 0;
+  font-size: 18px;
+  letter-spacing: 0.05em;
+  color: var(--accent);
+}
+
+#game {
+  border: 1px solid #2a2a3a;
+  background: #000;
+  line-height: 0;
+}
+
+#game canvas {
+  display: block;
+  image-rendering: pixelated;
+  image-rendering: crisp-edges;
+}
+
+#hud {
+  width: 100%;
+  max-width: 800px;
+}
+
+#status {
+  font-size: 14px;
+  color: var(--accent);
+  padding: 4px 8px;
+  background: #161621;
+  border: 1px solid #2a2a3a;
+}
+
+#log {
+  list-style: none;
+  margin: 4px 0 0 0;
+  padding: 4px 8px;
+  font-size: 13px;
+  color: var(--fg);
+  background: #12121b;
+  border: 1px solid #1f1f2c;
+  min-height: 96px;
+}
+
+#log li {
+  padding: 1px 0;
+}
+
+#log li:last-child {
+  color: var(--accent);
+}
+
+.help {
+  color: var(--muted);
+  font-size: 12px;
+  margin: 4px 0 0 0;
+}
+
+kbd {
+  background: #2a2a3a;
+  padding: 1px 5px;
+  border-radius: 3px;
+  font: inherit;
+}

--- a/simple-roguelike/src/ui/hud.ts
+++ b/simple-roguelike/src/ui/hud.ts
@@ -1,0 +1,58 @@
+/**
+ * Tiny DOM-based HUD. We render the sprite grid with PIXI; the status line
+ * and message log are just HTML elements under the canvas.
+ */
+
+const LOG_LIMIT = 6;
+
+export class MessageLog {
+  private items: string[] = [];
+
+  push(msg: string): void {
+    this.items.push(msg);
+    if (this.items.length > LOG_LIMIT) {
+      this.items = this.items.slice(-LOG_LIMIT);
+    }
+  }
+
+  clear(): void {
+    this.items = [];
+  }
+
+  all(): readonly string[] {
+    return this.items;
+  }
+}
+
+export interface HudState {
+  hp: number;
+  maxHp: number;
+  seed: number;
+  status: "alive" | "dead" | "escaped";
+}
+
+export class Hud {
+  private readonly statusEl: HTMLElement;
+  private readonly logEl: HTMLElement;
+
+  constructor(statusEl: HTMLElement, logEl: HTMLElement) {
+    this.statusEl = statusEl;
+    this.logEl = logEl;
+  }
+
+  render(state: HudState, log: MessageLog): void {
+    let trailer = "";
+    if (state.status === "dead") trailer = " · YOU DIED — press r to restart";
+    if (state.status === "escaped") trailer = " · YOU ESCAPED — press r for a new run";
+    this.statusEl.textContent =
+      `HP: ${state.hp}/${state.maxHp} · Seed: ${state.seed}${trailer}`;
+
+    // Rebuild the log as a simple <ul> of <li>s. Newest last.
+    this.logEl.textContent = "";
+    for (const line of log.all()) {
+      const li = document.createElement("li");
+      li.textContent = line;
+      this.logEl.appendChild(li);
+    }
+  }
+}

--- a/simple-roguelike/tests/fov.test.ts
+++ b/simple-roguelike/tests/fov.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { newVisibility, recomputeFov } from "../src/game/systems/fov";
+import { Tile } from "../src/game/map/tiles";
+import { TileMap } from "../src/game/map/tilemap";
+
+/** Build a small arena: Floor interior surrounded by Wall border. */
+function arena(width: number, height: number): TileMap {
+  const map = new TileMap(width, height, Tile.Wall);
+  for (let y = 1; y < height - 1; y++) {
+    for (let x = 1; x < width - 1; x++) {
+      map.set(x, y, Tile.Floor);
+    }
+  }
+  return map;
+}
+
+describe("recomputeFov", () => {
+  it("player sees their own tile", () => {
+    const map = arena(9, 9);
+    const vis = newVisibility();
+    recomputeFov(map, { x: 4, y: 4 }, 6, vis);
+    expect(vis.visible.has(4 * map.width + 4)).toBe(true);
+  });
+
+  it("walls block sight past them", () => {
+    const map = arena(11, 5);
+    // Drop a vertical wall at x=6, fully spanning the room height
+    for (let y = 1; y < 4; y++) map.set(6, y, Tile.Wall);
+    const vis = newVisibility();
+    recomputeFov(map, { x: 2, y: 2 }, 8, vis);
+    const idx = (x: number, y: number) => y * map.width + x;
+    // Near side is visible
+    expect(vis.visible.has(idx(5, 2))).toBe(true);
+    // Wall itself is visible (shadowcasting reveals the blocker)
+    expect(vis.visible.has(idx(6, 2))).toBe(true);
+    // Far side is NOT visible
+    expect(vis.visible.has(idx(8, 2))).toBe(false);
+    expect(vis.visible.has(idx(9, 2))).toBe(false);
+  });
+
+  it("seen set accumulates across recomputes (memory)", () => {
+    const map = arena(9, 9);
+    const vis = newVisibility();
+    recomputeFov(map, { x: 2, y: 2 }, 4, vis);
+    const firstSeen = new Set(vis.seen);
+    // Step to the far corner — new visible set, but the first batch should
+    // still live in `seen`.
+    recomputeFov(map, { x: 6, y: 6 }, 4, vis);
+    for (const i of firstSeen) {
+      expect(vis.seen.has(i)).toBe(true);
+    }
+  });
+
+  it("visible set resets between recomputes", () => {
+    const map = arena(9, 9);
+    const vis = newVisibility();
+    recomputeFov(map, { x: 2, y: 2 }, 3, vis);
+    const oldSize = vis.visible.size;
+    expect(oldSize).toBeGreaterThan(0);
+    recomputeFov(map, { x: 6, y: 6 }, 3, vis);
+    // The previous center tile is 4 away diagonally — outside radius 3 — so
+    // it must have dropped out of `visible`.
+    expect(vis.visible.has(2 * map.width + 2)).toBe(false);
+  });
+});

--- a/simple-roguelike/tests/generate.test.ts
+++ b/simple-roguelike/tests/generate.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { createRng } from "../src/game/rng";
+import { generateLevel } from "../src/game/map/generate";
+import { Tile } from "../src/game/map/tiles";
+
+describe("generateLevel", () => {
+  it("same seed produces the same map", () => {
+    const a = generateLevel(createRng(42), 48, 28);
+    const b = generateLevel(createRng(42), 48, 28);
+    const dumpA: Tile[] = [];
+    const dumpB: Tile[] = [];
+    for (const [, , t] of a.map.cells()) dumpA.push(t);
+    for (const [, , t] of b.map.cells()) dumpB.push(t);
+    expect(dumpA).toEqual(dumpB);
+    expect(a.spawn).toEqual(b.spawn);
+    expect(a.stairs).toEqual(b.stairs);
+  });
+
+  it("100 seeds all produce connected dungeons with reachable stairs", () => {
+    for (let seed = 1; seed <= 100; seed++) {
+      const { map, spawn, stairs } = generateLevel(createRng(seed), 48, 28);
+      // Spawn and stairs must be floor/stairs tiles.
+      expect(map.info(spawn.x, spawn.y).blocksMove).toBe(false);
+      expect(map.info(stairs.x, stairs.y).blocksMove).toBe(false);
+      // Stairs must be reachable from spawn — walk a BFS to prove it.
+      expect(reachable(map, spawn, stairs)).toBe(true);
+    }
+  });
+
+  it("places stairs away from spawn", () => {
+    for (let seed = 1; seed <= 20; seed++) {
+      const { spawn, stairs } = generateLevel(createRng(seed), 48, 28);
+      const manhattan = Math.abs(spawn.x - stairs.x) + Math.abs(spawn.y - stairs.y);
+      expect(manhattan).toBeGreaterThan(5);
+    }
+  });
+});
+
+function reachable(
+  map: import("../src/game/map/tilemap").TileMap,
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+): boolean {
+  const seen = new Set<string>();
+  const q: { x: number; y: number }[] = [from];
+  seen.add(`${from.x},${from.y}`);
+  const dirs = [
+    [0, -1],
+    [0, 1],
+    [-1, 0],
+    [1, 0],
+  ];
+  while (q.length > 0) {
+    const { x, y } = q.shift()!;
+    if (x === to.x && y === to.y) return true;
+    for (const [dx, dy] of dirs) {
+      const nx = x + dx;
+      const ny = y + dy;
+      if (!map.inBounds(nx, ny)) continue;
+      if (map.info(nx, ny).blocksMove) continue;
+      const key = `${nx},${ny}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      q.push({ x: nx, y: ny });
+    }
+  }
+  return false;
+}

--- a/simple-roguelike/tests/rng.test.ts
+++ b/simple-roguelike/tests/rng.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { createRng, pickSeed, randInt, roll } from "../src/game/rng";
+
+describe("createRng", () => {
+  it("produces the same sequence for the same seed", () => {
+    const a = createRng(12345);
+    const b = createRng(12345);
+    const seqA = Array.from({ length: 10 }, () => a());
+    const seqB = Array.from({ length: 10 }, () => b());
+    expect(seqA).toEqual(seqB);
+  });
+
+  it("produces different sequences for different seeds", () => {
+    const a = createRng(1);
+    const b = createRng(2);
+    expect(a()).not.toEqual(b());
+  });
+
+  it("returns values in [0, 1)", () => {
+    const r = createRng(42);
+    for (let i = 0; i < 1000; i++) {
+      const v = r();
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+});
+
+describe("randInt", () => {
+  it("stays within the inclusive bounds", () => {
+    const r = createRng(7);
+    for (let i = 0; i < 1000; i++) {
+      const v = randInt(r, 3, 9);
+      expect(v).toBeGreaterThanOrEqual(3);
+      expect(v).toBeLessThanOrEqual(9);
+      expect(Number.isInteger(v)).toBe(true);
+    }
+  });
+});
+
+describe("roll", () => {
+  it("1d6 is always in [1, 6]", () => {
+    const r = createRng(99);
+    for (let i = 0; i < 1000; i++) {
+      const v = roll(r, 1, 6);
+      expect(v).toBeGreaterThanOrEqual(1);
+      expect(v).toBeLessThanOrEqual(6);
+    }
+  });
+
+  it("2d4 is always in [2, 8]", () => {
+    const r = createRng(1);
+    for (let i = 0; i < 1000; i++) {
+      const v = roll(r, 2, 4);
+      expect(v).toBeGreaterThanOrEqual(2);
+      expect(v).toBeLessThanOrEqual(8);
+    }
+  });
+});
+
+describe("pickSeed", () => {
+  it("parses ?seed=123", () => {
+    expect(pickSeed("?seed=123")).toBe(123);
+  });
+
+  it("falls back when missing", () => {
+    const a = pickSeed("");
+    expect(Number.isFinite(a)).toBe(true);
+    expect(a).toBeGreaterThanOrEqual(0);
+  });
+
+  it("falls back when not a number", () => {
+    const a = pickSeed("?seed=hello");
+    expect(Number.isFinite(a)).toBe(true);
+  });
+});

--- a/simple-roguelike/tsconfig.json
+++ b/simple-roguelike/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "preserve",
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "types": ["vite/client", "node"]
+  },
+  "include": ["src", "tests"]
+}

--- a/simple-roguelike/vite.config.ts
+++ b/simple-roguelike/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  base: "/2D-game-playground/simple-roguelike/",
+  build: {
+    target: "es2022",
+  },
+});


### PR DESCRIPTION
## Summary

Two commits that together turn this empty repo into a playable game site:

1. **`f966e07` — Install Claude skills from zeroLR/skills.** Copies `game-scaffold`, `game-loop`, `game-systems`, `game-perf` SKILL.md files into `.claude/skills/` so Claude auto-invokes them for any further game work in this repo.
2. **`b87bd92` — Add simple-roguelike game + Pages deploy workflow.** A full turn-based roguelike in `simple-roguelike/`, built following the skills above, plus a GitHub Actions workflow that publishes it to GitHub Pages.

## What's in `simple-roguelike/`

- **Stack**: Vite + TypeScript (strict) + PixiJS 8 + rot-js (the literal default from `game-scaffold` for sprite-based roguelikes).
- **Loop**: pattern 3 — turn-based instant. `player → enemies → FOV → render` per input.
- **Map**: `ROT.Map.Digger` rooms/corridors with a BFS connectivity guard; stairs placed in the room farthest from spawn.
- **FOV**: `ROT.FOV.PreciseShadowcasting` radius 8; tiles render in three states (visible / seen / unseen).
- **AI**: `ROT.Path.AStar` — goblins idle until they've seen the player once, then hunt.
- **Determinism**: single seeded mulberry32 RNG lifted verbatim from `game-scaffold` §Phase 3; `?seed=123` reproduces runs.
- **ECS**: bag-of-components (`Map<EntityId, Components>`) from `game-systems`.
- **Sprites**: drawn procedurally in `src/render/textures.ts` via `PIXI.Graphics` (the Kenney mirror was network-blocked during development — retheme by editing that file).

Controls: arrows / `hjkl` move, `yubn` diagonals, `.` wait, `r` restart, bump to attack.

## GitHub Pages deployment

`.github/workflows/deploy.yml` uses the modern `actions/deploy-pages@v4` flow — no `gh-pages` branch. It:

1. Runs `npm ci && npm test && npm run build` in `simple-roguelike/`.
2. Assembles a Pages artifact with `simple-roguelike/dist/` copied into `_site/simple-roguelike/` and a small redirect `index.html` at `_site/` root.
3. Deploys via `actions/deploy-pages@v4`.

After merge, final URLs:
- https://zerolr.github.io/2D-game-playground/simple-roguelike/ — the game
- https://zerolr.github.io/2D-game-playground/ — redirects into the game (replace with a landing page once there are multiple games)

**One-time manual step**: in **Settings → Pages**, set **Source = GitHub Actions**. Pages can't be enabled from a workflow.

Adding a sibling game later is additive: new folder, its own `vite.config.ts` `base: "/2D-game-playground/<folder>/"`, add a matching `cp -r` step to `deploy.yml`, swap the root redirect for a real landing page.

## Test plan

Local (already run — all green on this branch):

- [x] `npx tsc --noEmit` — strict mode clean
- [x] `npx vitest run` — 16/16 pass (rng sequences, 100-seed dungeon connectivity, FOV visible/seen/memory)
- [x] `npm run build` — bundles ~255 kB (~80 kB gzip), asset URLs under `/2D-game-playground/simple-roguelike/`
- [x] `vite preview` — serves index.html with 200 under the subpath

Post-merge (please verify):

- [ ] Enable Pages (Settings → Pages → Source = GitHub Actions)
- [ ] `Deploy games to GitHub Pages` workflow runs green on the `main` push
- [ ] Visit https://zerolr.github.io/2D-game-playground/ — should redirect to `/simple-roguelike/`
- [ ] Play a full run (walk to stairs OR die to a goblin, then `r` to restart)
- [ ] DevTools Network tab shows no 404s under the subpath
- [ ] `?seed=1` in two tabs produces identical maps and identical enemy movement

https://claude.ai/code/session_01Ay3NLHK53GyytpRNC3qzuV