### PR TITLE
Make simple-roguelike mobile-playable + require platform decision up-front in game-scaffold

### DIFF
--- a/.claude/skills/game-scaffold/SKILL.md
+++ b/.claude/skills/game-scaffold/SKILL.md
@@ -14,16 +14,19 @@ Systematic kickoff for 2D web games (with a roguelike bias). The goal is to make
 
 ## Phase 0 — Clarify the concept before picking tech
 
-Do not pick a library until these are answered (ask the user if unknown):
+Do not pick a library until these are answered (ask the user if unknown). **Ask #1 first** — platform cascades into every decision below it, and adding mobile support late is expensive.
 
-1. **Turn-based or real-time?** (roguelikes are usually turn-based, but "coffee-break roguelites" like *Brogue*/*Slay the Spire* vs *Nuclear Throne* differ drastically)
-2. **Grid/tile-based or free movement?**
-3. **Render target**: ASCII, pixel-art sprites, or vector/shader?
-4. **Target platform**: desktop browser only, or mobile touch too?
+1. **Target platform** — desktop browser only, **mobile web (touch)**, or both? Also: portrait or landscape? Must work offline? PWA / installable?
+   - This is question #1 because it dictates input model (keyboard vs. touch), viewport math (fixed vs. responsive, safe-area insets), performance budget (a 2019 Android is ~5× slower than a MacBook), asset resolution (devicePixelRatio ≥ 2 on phones), and UI affordances (44×44 px minimum tap target). Retrofitting these after the fact usually means rewriting the input layer and the layout.
+   - **If mobile** is in scope, also jump to the "Mobile web games" callout in Phase 2 before scaffolding.
+2. **Turn-based or real-time?** (roguelikes are usually turn-based, but "coffee-break roguelites" like *Brogue*/*Slay the Spire* vs *Nuclear Throne* differ drastically)
+3. **Grid/tile-based or free movement?**
+4. **Render target**: ASCII, pixel-art sprites, or vector/shader?
+   - Warning: `ROT.Display` is not touch-aware — if the answer to #1 includes mobile, prefer PixiJS or raw Canvas so you can attach pointer events to the canvas yourself.
 5. **Scope**: 7-day jam, month-long prototype, or long-term project?
 6. **Procedural generation**: which layers? (map, items, enemies, narrative)
 
-Write the answers into `docs/concept.md` as a one-page mini-GDD before touching code.
+Write the answers into `docs/concept.md` as a one-page mini-GDD before touching code. The first line should be `Platform: <desktop | mobile | both> (<orientation>)` — make the commitment visible.
 
 ## Phase 1 — Tech stack decision matrix
 
@@ -39,6 +42,38 @@ Write the answers into `docs/concept.md` as a one-page mini-GDD before touching 
 **For a 2D roguelike, the default recommendation is: Vite + TypeScript + PixiJS + rot.js** (Pixi for rendering, rot.js for FOV/pathfinding/generation). Fall back to raw Canvas 2D if the user wants to learn internals, or Phaser if they want scene/physics/tweens out of the box.
 
 Record the choice and *why* in `docs/concept.md` — future-you will want to know.
+
+### Mobile web games — callout
+
+If Phase 0 #1 answered "mobile" or "both", bake these in from day one. Each of them is cheap to set up now and painful to bolt on later:
+
+- **Viewport meta** in `index.html`:
+  ```html
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="theme-color" content="#0d0d14" />
+  ```
+  `viewport-fit=cover` unlocks `env(safe-area-inset-*)` around the notch / home indicator.
+- **Touch-friendly canvas CSS**:
+  ```css
+  canvas {
+    display: block;
+    width: 100%;
+    max-width: min(100vw, 768px);
+    height: auto;
+    image-rendering: pixelated;
+    touch-action: none;      /* kill pinch-zoom + double-tap-zoom on the play area */
+    user-select: none;
+  }
+  body { overscroll-behavior: none; }  /* no pull-to-refresh mid-game */
+  #app { padding-bottom: env(safe-area-inset-bottom); }
+  ```
+- **Pointer events, not touch events** — `pointerdown` / `pointermove` / `pointerup` handle mouse, pen, and touch with one code path. Translate client coordinates to tile coordinates via `canvas.getBoundingClientRect()` so CSS scaling is handled transparently.
+- **Input duality** — keep keyboard bindings for desktop debugging, add on-screen buttons (Wait, Restart, maybe Inventory) so touch users can trigger actions that don't map to a tap-to-move. Button tap targets must be ≥ 44×44 CSS px.
+- **Map / viewport size** — phones run ~360–420 CSS px wide. A 16 px tile × 32 cols = 512 internal px that scales down cleanly. Grids bigger than ~40 cols force unreadable tiles at phone width unless you add camera scrolling. Decide the grid dimensions with the phone viewport in mind.
+- **Performance budget** — budget 8 ms/frame on a mid-tier Android, not 2 ms on your MacBook. Avoid allocations in the per-frame path from the start (see `game-perf` once you have numbers).
+- **PWA / offline** — optional for v1. If desired, add `vite-plugin-pwa` so the game works after first load without network.
+
+Test on a real phone (or at minimum Chrome DevTools device emulation with CPU throttling) **before** declaring the Phase 5 smoke test green. Emulation without throttling hides the performance cliff.
 
 ## Phase 2 — Scaffold
 

--- a/simple-roguelike/README.md
+++ b/simple-roguelike/README.md
@@ -4,12 +4,18 @@ A small turn-based roguelike built with Vite + TypeScript + PixiJS + rot-js. Dep
 
 ## Gameplay
 
+Designed for both desktop and mobile web — tap or keyboard, same game.
+
+**Mobile / touch:**
+- Tap a tile on the map to take one step toward it (8-way). Tap an adjacent enemy to bump-attack.
+- **Wait** button — burn a turn in place. **Restart** button — new seed.
+
+**Desktop / keyboard:**
 - Move with arrow keys or `hjkl` (diagonals: `yubn`).
 - `.` waits a turn. `r` restarts with a new seed.
 - Walk into enemies to bump-attack them.
-- Reach the stairs `>` to escape the dungeon.
 
-Append `?seed=123` to the URL to play a reproducible run.
+Reach the stairs `>` to escape the dungeon. Append `?seed=123` to the URL to play a reproducible run.
 
 ## Structure
 

--- a/simple-roguelike/index.html
+++ b/simple-roguelike/index.html
@@ -2,19 +2,31 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no"
+    />
+    <meta name="theme-color" content="#0d0d14" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <title>simple-roguelike</title>
   </head>
   <body>
     <main id="app">
       <h1>simple-roguelike</h1>
       <div id="game"></div>
+      <div id="controls">
+        <button type="button" id="btn-wait" class="ctrl-btn">Wait</button>
+        <button type="button" id="btn-restart" class="ctrl-btn">Restart</button>
+      </div>
       <div id="hud">
         <div id="status">HP: - · Seed: -</div>
         <ul id="log"></ul>
       </div>
       <p class="help">
-        Arrows / <kbd>hjkl</kbd> move · <kbd>.</kbd> wait · <kbd>r</kbd> restart · bump enemies to attack
+        Tap the map to step toward that tile · use <b>Wait</b> / <b>Restart</b> buttons on touch.
+        Desktop: Arrows / <kbd>hjkl</kbd> move · <kbd>.</kbd> wait · <kbd>r</kbd> restart · bump enemies to attack
       </p>
     </main>
     <script type="module" src="/src/main.ts"></script>

--- a/simple-roguelike/src/game/map/generate.ts
+++ b/simple-roguelike/src/game/map/generate.ts
@@ -21,9 +21,12 @@ export function generateLevel(rng: Rng, width: number, height: number): Generate
   // stays deterministic for a given game seed.
   for (let attempt = 0; attempt < 20; attempt++) {
     ROT.RNG.setSeed(Math.floor(rng() * 2 ** 31));
+    // Room sizes tuned for a 32×20 phone-friendly grid (see main.ts). Smaller
+    // rooms = more of them, which gives Digger room to place goblins far from
+    // the spawn even on a tight map.
     const digger = new ROT.Map.Digger(width, height, {
-      roomWidth: [4, 8],
-      roomHeight: [3, 6],
+      roomWidth: [3, 6],
+      roomHeight: [3, 5],
       dugPercentage: 0.25,
     });
     const map = new TileMap(width, height, Tile.Wall);

--- a/simple-roguelike/src/game/systems/input.ts
+++ b/simple-roguelike/src/game/systems/input.ts
@@ -30,3 +30,23 @@ const bindings: Record<string, Action> = {
 export function keyToAction(e: KeyboardEvent): Action | null {
   return bindings[e.key] ?? null;
 }
+
+/**
+ * Translate a tap on some tile into a one-step move toward that tile.
+ *
+ * The game is turn-based and tile-snapped, so instead of path-finding we just
+ * take one 8-way step in the direction of the tap. Tapping the tile the player
+ * is already standing on returns `null` so the caller can decide whether to
+ * wait, open a menu, etc.
+ */
+export function tapToAction(
+  tileX: number,
+  tileY: number,
+  playerX: number,
+  playerY: number,
+): Action | null {
+  const dx = Math.sign(tileX - playerX) as -1 | 0 | 1;
+  const dy = Math.sign(tileY - playerY) as -1 | 0 | 1;
+  if (dx === 0 && dy === 0) return null;
+  return { type: "move", dx, dy };
+}

--- a/simple-roguelike/src/main.ts
+++ b/simple-roguelike/src/main.ts
@@ -5,15 +5,18 @@ import { createRng, pickSeed } from "./game/rng";
 import { generateLevel } from "./game/map/generate";
 import { World } from "./game/world";
 import { spawnGoblin, spawnPlayer } from "./game/entities/factories";
-import { keyToAction } from "./game/systems/input";
+import { keyToAction, tapToAction, type Action } from "./game/systems/input";
 import { newVisibility, recomputeFov } from "./game/systems/fov";
 import { runTurn, type TurnOutcome } from "./game/turn";
 import { Hud, MessageLog } from "./ui/hud";
 import { buildTextures, TILE_SIZE } from "./render/textures";
 import { Stage } from "./render/stage";
 
-const MAP_W = 48;
-const MAP_H = 28;
+// Grid sized to fit portrait-phone viewports: 32×20 tiles at 16 px × ZOOM=2
+// is 1024×640 internal pixels, which CSS scales down to fit < 400 px wide
+// phones without losing the pixel-art look (see src/style.css).
+const MAP_W = 32;
+const MAP_H = 20;
 const FOV_RADIUS = 8;
 const ZOOM = 2;
 const GOBLIN_COUNT = 5;
@@ -58,11 +61,8 @@ async function main(): Promise<void> {
   let game = newGame(pickSeed(), stage);
   render(game, stage, hud);
 
-  window.addEventListener("keydown", (e) => {
-    const action = keyToAction(e);
-    if (!action) return;
-    e.preventDefault();
-
+  // One pathway for every input source: keyboard, tap, or on-screen button.
+  const apply = (action: Action): void => {
     if (action.type === "restart") {
       // New seed — show it in the HUD and console like the skill requests.
       const next = (game.seed + 1) >>> 0;
@@ -90,7 +90,44 @@ async function main(): Promise<void> {
     else if (outcome === "escaped") game.status = "escaped";
 
     render(game, stage, hud);
+  };
+
+  window.addEventListener("keydown", (e) => {
+    const action = keyToAction(e);
+    if (!action) return;
+    e.preventDefault();
+    apply(action);
   });
+
+  // Tap / click the canvas — translate the pixel offset into a tile, then
+  // take one 8-way step toward it. `pointerdown` covers mouse, pen, and touch
+  // with a single listener, and `touch-action: none` in style.css kills the
+  // browser's double-tap-zoom on phones.
+  app.canvas.addEventListener("pointerdown", (e) => {
+    e.preventDefault();
+    const rect = app.canvas.getBoundingClientRect();
+    // rect.width/height are the CSS-scaled size; app.canvas.width/height are
+    // the internal resolution. We map back into internal coords before dividing
+    // by the tile size × zoom so CSS scaling stays transparent.
+    const scaleX = app.canvas.width / rect.width;
+    const scaleY = app.canvas.height / rect.height;
+    const localX = (e.clientX - rect.left) * scaleX;
+    const localY = (e.clientY - rect.top) * scaleY;
+    const tileX = Math.floor(localX / (TILE_SIZE * ZOOM));
+    const tileY = Math.floor(localY / (TILE_SIZE * ZOOM));
+
+    const player = game.world.player();
+    const pos = player?.[1].position;
+    if (!pos) return;
+    const action = tapToAction(tileX, tileY, pos.x, pos.y);
+    if (action) apply(action);
+  });
+
+  // On-screen buttons — primary controls on mobile where there is no keyboard.
+  const waitBtn = document.getElementById("btn-wait");
+  const restartBtn = document.getElementById("btn-restart");
+  waitBtn?.addEventListener("click", () => apply({ type: "wait" }));
+  restartBtn?.addEventListener("click", () => apply({ type: "restart" }));
 }
 
 function newGame(seed: number, stage: Stage): Game {

--- a/simple-roguelike/src/style.css
+++ b/simple-roguelike/src/style.css
@@ -4,6 +4,8 @@
   --fg: #d6d6e0;
   --accent: #f0b850;
   --muted: #7a7a8a;
+  --panel: #161621;
+  --panel-border: #2a2a3a;
 }
 
 * {
@@ -17,16 +19,23 @@ html, body {
   color: var(--fg);
   font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
   min-height: 100vh;
+  /* Kill pull-to-refresh / bounce scroll while interacting with the game. */
+  overscroll-behavior: none;
 }
 
 #app {
   max-width: 900px;
   margin: 0 auto;
-  padding: 16px;
+  padding: 12px;
+  /* Respect notches and home indicators on phones. */
+  padding-top: max(12px, env(safe-area-inset-top));
+  padding-bottom: max(12px, env(safe-area-inset-bottom));
+  padding-left: max(12px, env(safe-area-inset-left));
+  padding-right: max(12px, env(safe-area-inset-right));
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 12px;
+  gap: 10px;
 }
 
 h1 {
@@ -37,34 +46,78 @@ h1 {
 }
 
 #game {
-  border: 1px solid #2a2a3a;
+  border: 1px solid var(--panel-border);
   background: #000;
   line-height: 0;
+  /* Let the inner canvas expand to the container width on mobile. */
+  width: 100%;
+  max-width: min(100vw - 24px, 768px);
 }
 
 #game canvas {
   display: block;
+  /* CSS-scale the internal 1024×640 resolution down to fit the viewport. */
+  width: 100%;
+  height: auto;
   image-rendering: pixelated;
   image-rendering: crisp-edges;
+  /* Block double-tap zoom and pinch-zoom inside the play area. */
+  touch-action: none;
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+#controls {
+  width: 100%;
+  max-width: 768px;
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+}
+
+.ctrl-btn {
+  flex: 1 1 0;
+  /* ≥ 44 px tap target per Apple HIG / WCAG. */
+  min-height: 48px;
+  padding: 10px 16px;
+  background: var(--panel);
+  color: var(--accent);
+  border: 1px solid var(--panel-border);
+  border-radius: 6px;
+  font: inherit;
+  font-size: 16px;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.ctrl-btn:hover {
+  border-color: var(--accent);
+}
+
+.ctrl-btn:active {
+  background: #1f1f2c;
 }
 
 #hud {
   width: 100%;
-  max-width: 800px;
+  max-width: 768px;
 }
 
 #status {
   font-size: 14px;
   color: var(--accent);
-  padding: 4px 8px;
-  background: #161621;
-  border: 1px solid #2a2a3a;
+  padding: 6px 8px;
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
 }
 
 #log {
   list-style: none;
   margin: 4px 0 0 0;
-  padding: 4px 8px;
+  padding: 6px 8px;
   font-size: 13px;
   color: var(--fg);
   background: #12121b;
@@ -84,6 +137,8 @@ h1 {
   color: var(--muted);
   font-size: 12px;
   margin: 4px 0 0 0;
+  line-height: 1.5;
+  text-align: center;
 }
 
 kbd {
@@ -91,4 +146,26 @@ kbd {
   padding: 1px 5px;
   border-radius: 3px;
   font: inherit;
+}
+
+/* Narrow phones — tighten padding and shrink the header. */
+@media (max-width: 480px) {
+  #app {
+    padding-left: max(8px, env(safe-area-inset-left));
+    padding-right: max(8px, env(safe-area-inset-right));
+    gap: 8px;
+  }
+  h1 {
+    font-size: 16px;
+  }
+  #game {
+    max-width: 100%;
+  }
+  .help {
+    font-size: 11px;
+  }
+  #log {
+    min-height: 72px;
+    font-size: 12px;
+  }
 }

--- a/simple-roguelike/tests/generate.test.ts
+++ b/simple-roguelike/tests/generate.test.ts
@@ -5,8 +5,8 @@ import { Tile } from "../src/game/map/tiles";
 
 describe("generateLevel", () => {
   it("same seed produces the same map", () => {
-    const a = generateLevel(createRng(42), 48, 28);
-    const b = generateLevel(createRng(42), 48, 28);
+    const a = generateLevel(createRng(42), 32, 20);
+    const b = generateLevel(createRng(42), 32, 20);
     const dumpA: Tile[] = [];
     const dumpB: Tile[] = [];
     for (const [, , t] of a.map.cells()) dumpA.push(t);
@@ -18,7 +18,7 @@ describe("generateLevel", () => {
 
   it("100 seeds all produce connected dungeons with reachable stairs", () => {
     for (let seed = 1; seed <= 100; seed++) {
-      const { map, spawn, stairs } = generateLevel(createRng(seed), 48, 28);
+      const { map, spawn, stairs } = generateLevel(createRng(seed), 32, 20);
       // Spawn and stairs must be floor/stairs tiles.
       expect(map.info(spawn.x, spawn.y).blocksMove).toBe(false);
       expect(map.info(stairs.x, stairs.y).blocksMove).toBe(false);
@@ -29,7 +29,7 @@ describe("generateLevel", () => {
 
   it("places stairs away from spawn", () => {
     for (let seed = 1; seed <= 20; seed++) {
-      const { spawn, stairs } = generateLevel(createRng(seed), 48, 28);
+      const { spawn, stairs } = generateLevel(createRng(seed), 32, 20);
       const manhattan = Math.abs(spawn.x - stairs.x) + Math.abs(spawn.y - stairs.y);
       expect(manhattan).toBeGreaterThan(5);
     }


### PR DESCRIPTION
## Summary

Forgot to say upfront that the target play device is **mobile** — this PR fixes both the game (so it's actually playable on a phone) and the skill that should have caught the omission (so the next game doesn't repeat the mistake).

One commit: `6e959d2`.

## `simple-roguelike/` — mobile-playable

- **Map shrink**: 48×28 → **32×20** tiles. Internal canvas is 1024×640 at ZOOM=2, which CSS-scales cleanly into a portrait phone viewport without horizontal scroll.
- **Tap-to-move**: `pointerdown` on the canvas translates CSS-pixel coords back to internal tile coords (via `getBoundingClientRect()` + the canvas resolution ratio), then takes one 8-way step toward the tapped tile. New `tapToAction` helper lives next to `keyToAction` in `src/game/systems/input.ts` and shares the same `Action` union, so both keyboard and touch go through the exact same `runTurn` pipeline.
- **On-screen buttons**: **Wait** and **Restart** buttons below the canvas, ≥48 px tall (Apple HIG / WCAG 2.5.5), wired to the same `apply(action)` function as the keyboard handler. Tap on the player's own tile returns `null` — Wait is button-only to avoid ambiguity.
- **Responsive CSS** (`src/style.css`):
  - Canvas: `width: 100%; height: auto; image-rendering: pixelated; touch-action: none; user-select: none` — kills double-tap zoom and pinch-zoom inside the play area while preserving crisp pixels.
  - Safe-area insets via `env(safe-area-inset-*)` around `#app` so the HUD isn't hidden under the notch / home indicator.
  - `overscroll-behavior: none` stops pull-to-refresh mid-game.
  - `@media (max-width: 480px)` trims padding, header size, and log height for small phones.
- **Viewport meta**: `viewport-fit=cover`, `theme-color=#0d0d14`, `mobile-web-app-capable` / `apple-mobile-web-app-capable` for installable / homescreen behavior.
- **Digger rooms** tuned for the smaller grid (`[3,6]×[3,5]`); `generate.test.ts` updated to match so the 100-seed connectivity guard tests what actually ships.
- **README**: documents the tap / button controls alongside the existing keyboard bindings.

## `.claude/skills/game-scaffold/SKILL.md` — decide platform first

- **Phase 0** reordered so **"Target platform"** is question #1 (was #4), with an explicit note that input model, viewport math, performance budget (~5× slower on mid-tier Android vs a MacBook), devicePixelRatio, and 44×44 px tap targets all cascade from it. Retrofitting any of those after the fact means rewriting the input layer and the layout.
- Added warning on Phase 0 #4 that `ROT.Display` is not touch-aware — if mobile is in scope, prefer PixiJS or raw Canvas so pointer events can be attached to the canvas yourself.
- New **"Mobile web games" callout** before Phase 2 with ready-to-paste:
  - viewport meta (`viewport-fit=cover`, `theme-color`)
  - touch-safe canvas CSS (`touch-action: none`, `image-rendering: pixelated`, `overscroll-behavior: none`, safe-area padding)
  - guidance on pointer events (not touch events) + `getBoundingClientRect()` for CSS-scaled canvases
  - input duality (keep keyboard for desktop debugging, add on-screen buttons ≥ 44 px)
  - phone-width grid sizing rule of thumb (16 px × 32 cols = 512 internal px scales cleanly)
  - perf budget reminder (8 ms/frame on mid-tier Android, not 2 ms on your MacBook)
  - PWA pointer (`vite-plugin-pwa`) for offline-capable v1+
  - reminder to test on a real phone *or* Chrome DevTools device emulation **with CPU throttling** before calling the Phase 5 smoke test green.
- `docs/concept.md` now required to start with a one-line `Platform: <desktop | mobile | both> (<orientation>)` commitment so the decision is visible.

## Test plan

Local — all green on this branch:

- [x] `npx tsc --noEmit` — strict mode clean
- [x] `npx vitest run` — 16/16 pass (3 test files; generate tests re-run at the new 32×20 dimensions)
- [x] `npm run build` — `dist/` built, bundle unchanged in size
- [x] `vite preview` at `/2D-game-playground/simple-roguelike/` — 200, built `index.html` contains the new `btn-wait` / `btn-restart` buttons and `viewport-fit=cover` / `theme-color` meta tags

Post-merge / manual — needs a phone or DevTools device emulation:

- [ ] GitHub Pages deploy succeeds on the push to `main`
- [ ] Open https://zerolr.github.io/2D-game-playground/simple-roguelike/ on a phone — canvas fits viewport, no horizontal scroll, tiles stay pixel-perfect
- [ ] Tap a floor tile — player steps toward it; tap an adjacent goblin — bump-attack fires
- [ ] Wait / Restart buttons work; buttons are visually tappable (≥ 44 px)
- [ ] Safe-area: on an iPhone with a notch, no HUD text is clipped
- [ ] Double-tap on the canvas does **not** zoom the page
- [ ] Pull-down at the top of the page does **not** trigger pull-to-refresh
- [ ] `?seed=1` in two tabs still produces identical maps (determinism unchanged)
- [ ] Desktop keyboard controls still work (arrows, `hjkl`, `.`, `r`)

https://claude.ai/code/session_01Ay3NLHK53GyytpRNC3qzuV