### PR TITLE
Add STR/DEF stat system with XP-based level-up

### DIFF
--- a/simple-roguelike/src/game/entities/factories.ts
+++ b/simple-roguelike/src/game/entities/factories.ts
@@ -7,6 +7,8 @@ export function spawnPlayer(world: World, x: number, y: number): EntityId {
     blocker: true,
     health: { hp: 20, max: 20 },
     combat: { damageDice: [1, 6] },
+    stats: { str: 2, def: 1 },
+    experience: { xp: 0, level: 1 },
     name: "you",
     player: true,
   });
@@ -19,6 +21,8 @@ export function spawnGoblin(world: World, x: number, y: number): EntityId {
     blocker: true,
     health: { hp: 5, max: 5 },
     combat: { damageDice: [1, 3] },
+    stats: { str: 0, def: 0 },
+    xpReward: 3,
     ai: { kind: "hostile", hasSeenPlayer: false },
     name: "the goblin",
   });

--- a/simple-roguelike/src/game/systems/combat.ts
+++ b/simple-roguelike/src/game/systems/combat.ts
@@ -1,12 +1,45 @@
-import type { EntityId, World } from "../world";
+import type { Components, EntityId, World } from "../world";
 import type { Rng } from "../rng";
 import { roll } from "../rng";
 import type { MessageLog } from "../../ui/hud";
 
+// ---------------------------------------------------------------------------
+// Level-up helpers
+// ---------------------------------------------------------------------------
+
+/** XP required to advance from `level` to the next. */
+export function xpForNextLevel(level: number): number {
+  return level * 5; // lv1→2 = 5, lv2→3 = 10, …
+}
+
 /**
- * Resolve an attack from `attacker` to `target`. Rolls damage, applies it,
- * pushes a message, and removes the target if it died.
+ * Award `amount` XP to an entity that has the `experience` component.
+ * Handles multi-level-ups when the XP exceeds more than one threshold.
+ */
+export function gainXp(player: Components, amount: number, log: MessageLog): void {
+  if (!player.experience || !player.stats || !player.health) return;
+  player.experience.xp += amount;
+  while (player.experience.xp >= xpForNextLevel(player.experience.level)) {
+    player.experience.xp -= xpForNextLevel(player.experience.level);
+    player.experience.level += 1;
+    player.stats.str += 1;
+    player.stats.def += 1;
+    player.health.max += 3;
+    player.health.hp = Math.min(player.health.max, player.health.hp + 3);
+    log.push(`You feel stronger! (Lv ${player.experience.level})`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Attack resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve an attack from `attacker` to `target`.
  *
+ * Damage = max(1, diceRoll + attacker.STR − target.DEF).
+ *
+ * On kill the attacker receives XP if the target carries an `xpReward`.
  * Returns `true` if the target died as a result.
  */
 export function attack(
@@ -21,7 +54,10 @@ export function attack(
   if (!atkC || !tgtC || !tgtC.health || !atkC.combat) return false;
 
   const [n, sides] = atkC.combat.damageDice;
-  const dmg = roll(rng, n, sides);
+  const raw = roll(rng, n, sides);
+  const str = atkC.stats?.str ?? 0;
+  const def = tgtC.stats?.def ?? 0;
+  const dmg = Math.max(1, raw + str - def);
   tgtC.health.hp = Math.max(0, tgtC.health.hp - dmg);
 
   const atkName = atkC.name ?? "something";
@@ -30,6 +66,10 @@ export function attack(
 
   if (tgtC.health.hp <= 0) {
     log.push(`${capitalize(tgtName)} dies.`);
+    // Award XP to the attacker (if applicable).
+    if (tgtC.xpReward && atkC.experience) {
+      gainXp(atkC, tgtC.xpReward, log);
+    }
     // Don't remove the player — main.ts handles the death overlay.
     if (!tgtC.player) world.remove(target);
     return true;

--- a/simple-roguelike/src/game/world.ts
+++ b/simple-roguelike/src/game/world.ts
@@ -16,6 +16,12 @@ export interface Components {
   health?: { hp: number; max: number };
   ai?: { kind: "hostile"; hasSeenPlayer: boolean };
   combat?: { damageDice: [number, number] }; // [n, sides] — e.g. [1, 6] for 1d6
+  /** Attack / defense attributes. Any entity that participates in combat should have this. */
+  stats?: { str: number; def: number };
+  /** Player-only progression data. */
+  experience?: { xp: number; level: number };
+  /** XP awarded to the killer when this entity dies. */
+  xpReward?: number;
   name?: string;
   /** Tag for the one player entity — systems read this to find "the player". */
   player?: true;

--- a/simple-roguelike/src/main.ts
+++ b/simple-roguelike/src/main.ts
@@ -9,6 +9,7 @@ import { keyToAction, tapToAction, type Action } from "./game/systems/input";
 import { newVisibility, recomputeFov } from "./game/systems/fov";
 import { runTurn, type TurnOutcome } from "./game/turn";
 import { Hud, MessageLog } from "./ui/hud";
+import { xpForNextLevel } from "./game/systems/combat";
 import { buildTextures, TILE_SIZE } from "./render/textures";
 import { Stage } from "./render/stage";
 
@@ -156,11 +157,20 @@ function newGame(seed: number, stage: Stage): Game {
 function render(game: Game, stage: Stage, hud: Hud): void {
   stage.redraw(game.world, game.vis);
   const player = game.world.player();
-  const health = player?.[1].health;
+  const pc = player?.[1];
+  const health = pc?.health;
+  const stats = pc?.stats;
+  const exp = pc?.experience;
+  const level = exp?.level ?? 1;
   hud.render(
     {
       hp: health?.hp ?? 0,
       maxHp: health?.max ?? 0,
+      str: stats?.str ?? 0,
+      def: stats?.def ?? 0,
+      level,
+      xp: exp?.xp ?? 0,
+      xpNext: xpForNextLevel(level),
       seed: game.seed,
       status: game.status,
     },

--- a/simple-roguelike/src/ui/hud.ts
+++ b/simple-roguelike/src/ui/hud.ts
@@ -27,6 +27,11 @@ export class MessageLog {
 export interface HudState {
   hp: number;
   maxHp: number;
+  str: number;
+  def: number;
+  level: number;
+  xp: number;
+  xpNext: number;
   seed: number;
   status: "alive" | "dead" | "escaped";
 }
@@ -45,7 +50,7 @@ export class Hud {
     if (state.status === "dead") trailer = " · YOU DIED — press r to restart";
     if (state.status === "escaped") trailer = " · YOU ESCAPED — press r for a new run";
     this.statusEl.textContent =
-      `HP: ${state.hp}/${state.maxHp} · Seed: ${state.seed}${trailer}`;
+      `HP: ${state.hp}/${state.maxHp} · STR: ${state.str} · DEF: ${state.def} · Lv ${state.level} (${state.xp}/${state.xpNext} xp) · Seed: ${state.seed}${trailer}`;
 
     // Rebuild the log as a simple <ul> of <li>s. Newest last.
     this.logEl.textContent = "";

--- a/simple-roguelike/tests/combat.test.ts
+++ b/simple-roguelike/tests/combat.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+import { World } from "../src/game/world";
+import { createRng } from "../src/game/rng";
+import { attack, gainXp, xpForNextLevel } from "../src/game/systems/combat";
+import { MessageLog } from "../src/ui/hud";
+
+/** Helper: spawn a minimal attacker entity. */
+function spawnAttacker(
+  world: World,
+  opts: { dice?: [number, number]; str?: number; isPlayer?: boolean },
+) {
+  return world.create({
+    position: { x: 0, y: 0 },
+    health: { hp: 20, max: 20 },
+    combat: { damageDice: opts.dice ?? [1, 6] },
+    stats: { str: opts.str ?? 0, def: 0 },
+    ...(opts.isPlayer
+      ? { player: true, experience: { xp: 0, level: 1 }, name: "you" }
+      : { name: "attacker" }),
+  });
+}
+
+/** Helper: spawn a minimal target entity. */
+function spawnTarget(
+  world: World,
+  opts: { hp?: number; def?: number; xpReward?: number },
+) {
+  return world.create({
+    position: { x: 1, y: 0 },
+    health: { hp: opts.hp ?? 10, max: opts.hp ?? 10 },
+    blocker: true,
+    stats: { str: 0, def: opts.def ?? 0 },
+    ...(opts.xpReward !== undefined ? { xpReward: opts.xpReward } : {}),
+    name: "target",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Damage formula
+// ---------------------------------------------------------------------------
+
+describe("attack – damage formula", () => {
+  it("adds STR to dice roll", () => {
+    const world = new World();
+    const rng = createRng(42);
+    const log = new MessageLog();
+    // Use [1,1] so dice always roll 1 — isolate STR effect.
+    const atk = spawnAttacker(world, { dice: [1, 1], str: 2 });
+    const tgt = spawnTarget(world, { hp: 10, def: 0 });
+
+    attack(world, atk, tgt, rng, log);
+    // dmg = max(1, 1 + 2 - 0) = 3
+    expect(world.get(tgt)!.health!.hp).toBe(7);
+  });
+
+  it("subtracts target DEF from damage", () => {
+    const world = new World();
+    const rng = createRng(42);
+    const log = new MessageLog();
+    const atk = spawnAttacker(world, { dice: [1, 1], str: 0 });
+    const tgt = spawnTarget(world, { hp: 10, def: 1 });
+
+    attack(world, atk, tgt, rng, log);
+    // dmg = max(1, 1 + 0 - 1) = max(1, 0) = 1
+    expect(world.get(tgt)!.health!.hp).toBe(9);
+  });
+
+  it("floors damage at 1 even when DEF far exceeds roll + STR", () => {
+    const world = new World();
+    const rng = createRng(42);
+    const log = new MessageLog();
+    const atk = spawnAttacker(world, { dice: [1, 1], str: 0 });
+    const tgt = spawnTarget(world, { hp: 10, def: 99 });
+
+    attack(world, atk, tgt, rng, log);
+    // dmg = max(1, 1 + 0 - 99) = 1
+    expect(world.get(tgt)!.health!.hp).toBe(9);
+  });
+
+  it("logs the final damage amount", () => {
+    const world = new World();
+    const rng = createRng(42);
+    const log = new MessageLog();
+    const atk = spawnAttacker(world, { dice: [1, 1], str: 3 });
+    spawnTarget(world, { hp: 20, def: 1 });
+
+    attack(world, atk, 2, rng, log);
+    // dmg = max(1, 1 + 3 - 1) = 3
+    expect(log.all().some((m) => m.includes("for 3"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Kill & XP
+// ---------------------------------------------------------------------------
+
+describe("attack – kill & XP award", () => {
+  it("awards xpReward to the player on kill", () => {
+    const world = new World();
+    const rng = createRng(42);
+    const log = new MessageLog();
+    const atk = spawnAttacker(world, { dice: [1, 6], str: 10, isPlayer: true });
+    spawnTarget(world, { hp: 1, def: 0, xpReward: 3 });
+
+    const killed = attack(world, atk, 2, rng, log);
+    expect(killed).toBe(true);
+    expect(world.get(atk)!.experience!.xp).toBe(3);
+  });
+
+  it("does not award XP when attacker has no experience component", () => {
+    const world = new World();
+    const rng = createRng(42);
+    const log = new MessageLog();
+    // Non-player attacker (no experience component)
+    const atk = spawnAttacker(world, { dice: [1, 6], str: 10 });
+    spawnTarget(world, { hp: 1, def: 0, xpReward: 5 });
+
+    attack(world, atk, 2, rng, log);
+    // attacker should have no experience field at all
+    expect(world.get(atk)!.experience).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// xpForNextLevel
+// ---------------------------------------------------------------------------
+
+describe("xpForNextLevel", () => {
+  it("returns level * 5", () => {
+    expect(xpForNextLevel(1)).toBe(5);
+    expect(xpForNextLevel(2)).toBe(10);
+    expect(xpForNextLevel(3)).toBe(15);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gainXp / level-up
+// ---------------------------------------------------------------------------
+
+describe("gainXp", () => {
+  it("accumulates XP without leveling when below threshold", () => {
+    const world = new World();
+    const log = new MessageLog();
+    const id = spawnAttacker(world, { isPlayer: true });
+    const pc = world.get(id)!;
+
+    gainXp(pc, 4, log); // need 5 to level → stays lv 1
+    expect(pc.experience!.xp).toBe(4);
+    expect(pc.experience!.level).toBe(1);
+    expect(log.all().length).toBe(0);
+  });
+
+  it("levels up at exactly the threshold", () => {
+    const world = new World();
+    const log = new MessageLog();
+    const id = spawnAttacker(world, { isPlayer: true });
+    const pc = world.get(id)!;
+
+    gainXp(pc, 5, log); // exactly lv1→2 threshold
+    expect(pc.experience!.level).toBe(2);
+    expect(pc.experience!.xp).toBe(0);
+  });
+
+  it("increases STR and DEF by 1 on level-up", () => {
+    const world = new World();
+    const log = new MessageLog();
+    const id = spawnAttacker(world, { isPlayer: true, str: 2 });
+    const pc = world.get(id)!;
+    pc.stats!.def = 1; // set initial DEF
+
+    gainXp(pc, 5, log);
+    expect(pc.stats!.str).toBe(3);
+    expect(pc.stats!.def).toBe(2);
+  });
+
+  it("increases max HP by 3 and heals 3 on level-up", () => {
+    const world = new World();
+    const log = new MessageLog();
+    const id = spawnAttacker(world, { isPlayer: true });
+    const pc = world.get(id)!;
+    pc.health!.hp = 10; // simulate damage taken
+
+    gainXp(pc, 5, log);
+    expect(pc.health!.max).toBe(23);
+    expect(pc.health!.hp).toBe(13);
+  });
+
+  it("does not overheal past max HP", () => {
+    const world = new World();
+    const log = new MessageLog();
+    const id = spawnAttacker(world, { isPlayer: true });
+    const pc = world.get(id)!;
+    // At full HP (20/20), level-up raises max to 23 and heals 3 → should cap at 23.
+    gainXp(pc, 5, log);
+    expect(pc.health!.hp).toBe(23);
+    expect(pc.health!.max).toBe(23);
+  });
+
+  it("logs a level-up message", () => {
+    const world = new World();
+    const log = new MessageLog();
+    const id = spawnAttacker(world, { isPlayer: true });
+    const pc = world.get(id)!;
+
+    gainXp(pc, 5, log);
+    expect(log.all().some((m) => m.includes("Lv 2"))).toBe(true);
+  });
+
+  it("handles multi-level-up in a single XP grant", () => {
+    const world = new World();
+    const log = new MessageLog();
+    const id = spawnAttacker(world, { isPlayer: true, str: 0 });
+    const pc = world.get(id)!;
+
+    // lv1→2 costs 5, lv2→3 costs 10 → total 15 to reach lv3
+    gainXp(pc, 15, log);
+    expect(pc.experience!.level).toBe(3);
+    expect(pc.experience!.xp).toBe(0);
+    expect(pc.stats!.str).toBe(2); // +1 per level, started at 0
+    expect(pc.health!.max).toBe(26); // 20 + 3 + 3
+  });
+});


### PR DESCRIPTION
Introduce a stats component (str, def) and experience/xpReward components
to the ECS. Combat now uses: damage = max(1, diceRoll + STR - DEF).
Killing enemies awards XP; leveling up grants +1 STR, +1 DEF, +3 max HP.
HUD displays STR, DEF, level, and XP progress. Includes 14 unit tests.

https://claude.ai/code/session_01LdfXkfjPG5FCcGPMEpy2Ny