### PR TITLE
Roguelike stat system + enemy variety + mobile D-pad

### DIFF
--- a/simple-roguelike/index.html
+++ b/simple-roguelike/index.html
@@ -16,16 +16,24 @@
     <main id="app">
       <h1>simple-roguelike</h1>
       <div id="game"></div>
-      <div id="controls">
-        <button type="button" id="btn-wait" class="ctrl-btn">Wait</button>
-        <button type="button" id="btn-restart" class="ctrl-btn">Restart</button>
-      </div>
       <div id="hud">
         <div id="status">HP: - · Seed: -</div>
         <ul id="log"></ul>
       </div>
+      <div id="controls">
+        <div id="dpad" role="group" aria-label="Movement controls">
+          <button type="button" id="btn-up"      class="dpad-btn dpad-up"      aria-label="Move up">&uarr;</button>
+          <button type="button" id="btn-left"    class="dpad-btn dpad-left"    aria-label="Move left">&larr;</button>
+          <button type="button" id="btn-confirm" class="dpad-btn dpad-confirm" aria-label="Confirm / wait">OK</button>
+          <button type="button" id="btn-right"   class="dpad-btn dpad-right"   aria-label="Move right">&rarr;</button>
+          <button type="button" id="btn-down"    class="dpad-btn dpad-down"    aria-label="Move down">&darr;</button>
+        </div>
+        <div id="actions">
+          <button type="button" id="btn-restart" class="ctrl-btn">Restart</button>
+        </div>
+      </div>
       <p class="help">
-        Tap the map to step toward that tile · use <b>Wait</b> / <b>Restart</b> buttons on touch.
+        Tap the map to step toward that tile · use the D-pad and <b>OK</b> on touch.
         Desktop: Arrows / <kbd>hjkl</kbd> move · <kbd>.</kbd> wait · <kbd>r</kbd> restart · bump enemies to attack
       </p>
     </main>

--- a/simple-roguelike/src/game/entities/factories.ts
+++ b/simple-roguelike/src/game/entities/factories.ts
@@ -27,3 +27,45 @@ export function spawnGoblin(world: World, x: number, y: number): EntityId {
     name: "the goblin",
   });
 }
+
+export function spawnRat(world: World, x: number, y: number): EntityId {
+  return world.create({
+    position: { x, y },
+    renderable: { sprite: "rat" },
+    blocker: true,
+    health: { hp: 3, max: 3 },
+    combat: { damageDice: [1, 2] },
+    stats: { str: 0, def: 0 },
+    xpReward: 1,
+    ai: { kind: "hostile", hasSeenPlayer: false },
+    name: "the rat",
+  });
+}
+
+export function spawnOrc(world: World, x: number, y: number): EntityId {
+  return world.create({
+    position: { x, y },
+    renderable: { sprite: "orc" },
+    blocker: true,
+    health: { hp: 9, max: 9 },
+    combat: { damageDice: [1, 4] },
+    stats: { str: 2, def: 1 },
+    xpReward: 6,
+    ai: { kind: "hostile", hasSeenPlayer: false },
+    name: "the orc",
+  });
+}
+
+export function spawnTroll(world: World, x: number, y: number): EntityId {
+  return world.create({
+    position: { x, y },
+    renderable: { sprite: "troll" },
+    blocker: true,
+    health: { hp: 18, max: 18 },
+    combat: { damageDice: [2, 4] },
+    stats: { str: 4, def: 2 },
+    xpReward: 15,
+    ai: { kind: "hostile", hasSeenPlayer: false },
+    name: "the troll",
+  });
+}

--- a/simple-roguelike/src/game/systems/ai.ts
+++ b/simple-roguelike/src/game/systems/ai.ts
@@ -3,14 +3,52 @@ import * as ROT from "rot-js";
 import type { EntityId, World } from "../world";
 import type { TileMap } from "../map/tilemap";
 import type { Rng } from "../rng";
+import { randInt } from "../rng";
 import type { Visibility } from "./fov";
 import { canWalk, tryMove } from "./movement";
 import type { MessageLog } from "../../ui/hud";
 
+/** 8-way neighbor offsets (no "stay put" — waiting is handled separately). */
+const WANDER_DIRS: Array<[number, number]> = [
+  [-1, -1], [0, -1], [1, -1],
+  [-1, 0],           [1, 0],
+  [-1, 1],  [0, 1],  [1, 1],
+];
+
+/** Probability an idle enemy simply stays still on any given turn. */
+const WANDER_IDLE_CHANCE = 0.5;
+
+/**
+ * Enemies that have never spotted the player loiter in place or drift one
+ * tile at a time. Exported for unit tests. Returns the `[dx, dy]` actually
+ * taken, or `null` if the enemy idled / the chosen direction was blocked.
+ */
+export function wanderStep(
+  world: World,
+  map: TileMap,
+  id: EntityId,
+  rng: Rng,
+  log: MessageLog,
+): [number, number] | null {
+  const c = world.get(id);
+  if (!c?.position) return null;
+
+  // Half the time, just stand still so wandering feels organic rather than manic.
+  if (rng() < WANDER_IDLE_CHANCE) return null;
+
+  const [dx, dy] = WANDER_DIRS[randInt(rng, 0, WANDER_DIRS.length - 1)];
+  const nx = c.position.x + dx;
+  const ny = c.position.y + dy;
+  if (!canWalk(world, map, nx, ny)) return null;
+
+  tryMove(world, map, id, dx, dy, rng, log);
+  return [dx, dy];
+}
+
 /**
  * Step every hostile one tile closer to the player via A*. Enemies who have
- * never seen the player stay put. Once they've been in the player's FOV even
- * once, `hasSeenPlayer` flips true and they keep hunting.
+ * never seen the player wander around their room; once they've been in the
+ * player's FOV even once, `hasSeenPlayer` flips true and they keep hunting.
  *
  * Uses `ROT.Path.AStar` with a passability callback that treats occupied
  * enemy tiles as blockers — except the goal tile (the player) so A* can
@@ -43,7 +81,11 @@ export function enemiesAct(
     const i = c.position.y * map.width + c.position.x;
     const canSeePlayer = vis.visible.has(i);
     if (canSeePlayer) c.ai.hasSeenPlayer = true;
-    if (!c.ai.hasSeenPlayer) continue;
+    if (!c.ai.hasSeenPlayer) {
+      // Idle exploration: drift around rather than standing still.
+      wanderStep(world, map, id, rng, log);
+      continue;
+    }
 
     const astar = new ROT.Path.AStar(pos.x, pos.y, (x: number, y: number) => {
       if (!map.inBounds(x, y)) return false;

--- a/simple-roguelike/src/game/world.ts
+++ b/simple-roguelike/src/game/world.ts
@@ -7,7 +7,7 @@
 export type EntityId = number;
 
 /** Identifies which sprite this entity uses in the render layer. */
-export type SpriteKey = "player" | "goblin";
+export type SpriteKey = "player" | "goblin" | "rat" | "orc" | "troll";
 
 export interface Components {
   position?: { x: number; y: number };

--- a/simple-roguelike/src/main.ts
+++ b/simple-roguelike/src/main.ts
@@ -4,7 +4,13 @@ import { Application } from "pixi.js";
 import { createRng, pickSeed } from "./game/rng";
 import { generateLevel } from "./game/map/generate";
 import { World } from "./game/world";
-import { spawnGoblin, spawnPlayer } from "./game/entities/factories";
+import {
+  spawnGoblin,
+  spawnOrc,
+  spawnPlayer,
+  spawnRat,
+  spawnTroll,
+} from "./game/entities/factories";
 import { keyToAction, tapToAction, type Action } from "./game/systems/input";
 import { newVisibility, recomputeFov } from "./game/systems/fov";
 import { runTurn, type TurnOutcome } from "./game/turn";
@@ -20,7 +26,7 @@ const MAP_W = 32;
 const MAP_H = 20;
 const FOV_RADIUS = 8;
 const ZOOM = 2;
-const GOBLIN_COUNT = 5;
+const ENEMY_COUNT = 6;
 
 interface Game {
   seed: number;
@@ -125,9 +131,29 @@ async function main(): Promise<void> {
   });
 
   // On-screen buttons — primary controls on mobile where there is no keyboard.
-  const waitBtn = document.getElementById("btn-wait");
+  // 4-directional D-pad: each arrow emits one cardinal move.
+  const dpadBindings: Array<[string, { dx: -1 | 0 | 1; dy: -1 | 0 | 1 }]> = [
+    ["btn-up",    { dx: 0,  dy: -1 }],
+    ["btn-down",  { dx: 0,  dy: 1 }],
+    ["btn-left",  { dx: -1, dy: 0 }],
+    ["btn-right", { dx: 1,  dy: 0 }],
+  ];
+  for (const [id, step] of dpadBindings) {
+    const btn = document.getElementById(id);
+    btn?.addEventListener("click", () => apply({ type: "move", ...step }));
+  }
+
+  // Confirm is context-aware:
+  //   • Game over (dead / escaped) → start a new run
+  //   • On stairs → wait (turn.ts then returns "escaped")
+  //   • Otherwise → wait in place
+  const confirmBtn = document.getElementById("btn-confirm");
+  confirmBtn?.addEventListener("click", () => {
+    if (game.status !== "alive") apply({ type: "restart" });
+    else apply({ type: "wait" });
+  });
+
   const restartBtn = document.getElementById("btn-restart");
-  waitBtn?.addEventListener("click", () => apply({ type: "wait" }));
   restartBtn?.addEventListener("click", () => apply({ type: "restart" }));
 }
 
@@ -139,9 +165,23 @@ function newGame(seed: number, stage: Stage): Game {
 
   spawnPlayer(world, spawn.x, spawn.y);
 
-  // Drop goblins in the rooms farthest from the player, up to GOBLIN_COUNT.
-  const enemyRooms = roomCenters.slice(1, GOBLIN_COUNT + 1);
-  for (const c of enemyRooms) spawnGoblin(world, c.x, c.y);
+  // Place enemies in all rooms except the player's (index 0). The room farthest
+  // from the spawn becomes the troll's lair; the rest get a weighted mix of
+  // rats / goblins / orcs so each run feels a bit different.
+  const enemyRooms = roomCenters.slice(1, ENEMY_COUNT + 1);
+  if (enemyRooms.length > 0) {
+    const ranked = enemyRooms
+      .map((c) => ({ c, d: Math.abs(c.x - spawn.x) + Math.abs(c.y - spawn.y) }))
+      .sort((a, b) => b.d - a.d);
+    spawnTroll(world, ranked[0].c.x, ranked[0].c.y);
+    for (let i = 1; i < ranked.length; i++) {
+      const { c } = ranked[i];
+      const r = rng();
+      if (r < 0.35) spawnRat(world, c.x, c.y);
+      else if (r < 0.75) spawnGoblin(world, c.x, c.y);
+      else spawnOrc(world, c.x, c.y);
+    }
+  }
 
   const vis = newVisibility();
   recomputeFov(map, spawn, FOV_RADIUS, vis);

--- a/simple-roguelike/src/render/textures.ts
+++ b/simple-roguelike/src/render/textures.ts
@@ -26,6 +26,9 @@ export function buildTextures(app: Application): TextureBank {
     sprites: {
       player: makeTexture(app, drawPlayer),
       goblin: makeTexture(app, drawGoblin),
+      rat: makeTexture(app, drawRat),
+      orc: makeTexture(app, drawOrc),
+      troll: makeTexture(app, drawTroll),
     },
   };
 }
@@ -153,4 +156,99 @@ function drawGoblin(g: Graphics): void {
   // club
   g.rect(3, 5, 1, 5).fill(0x8a5a1a);
   g.rect(2, 5, 3, 1).fill(0x5a3a14);
+}
+
+function drawRat(g: Graphics): void {
+  // Small, low-slung rodent — sits in the bottom half of the tile.
+  // body
+  g.rect(4, 9, 7, 4).fill(0x7a6a58);
+  g.rect(3, 10, 1, 2).fill(0x7a6a58);
+  // back highlight
+  g.rect(4, 9, 7, 1).fill(0x9a8a70);
+  // head
+  g.rect(10, 8, 4, 4).fill(0x8a7a68);
+  // ears
+  g.rect(11, 7, 1, 1).fill(0x5a4a38);
+  g.rect(13, 7, 1, 1).fill(0x5a4a38);
+  // eye
+  g.rect(12, 9, 1, 1).fill(0xd62828);
+  // nose
+  g.rect(14, 10, 1, 1).fill(0xf0a0a0);
+  // legs
+  g.rect(5, 13, 1, 2).fill(0x5a4a38);
+  g.rect(9, 13, 1, 2).fill(0x5a4a38);
+  // tail — whip curving up-right
+  g.rect(1, 11, 3, 1).fill(0xa08878);
+  g.rect(0, 10, 1, 1).fill(0xa08878);
+}
+
+function drawOrc(g: Graphics): void {
+  // Bigger, broader, darker than a goblin. Brown tones + iron helm.
+  // helm
+  g.rect(5, 1, 6, 2).fill(0x5a5a6a);
+  g.rect(4, 2, 1, 1).fill(0x5a5a6a);
+  g.rect(11, 2, 1, 1).fill(0x5a5a6a);
+  // head
+  g.rect(5, 3, 6, 4).fill(0x6a7a3a);
+  g.rect(4, 4, 1, 2).fill(0x6a7a3a);
+  g.rect(11, 4, 1, 2).fill(0x6a7a3a);
+  // brow shadow
+  g.rect(5, 3, 6, 1).fill(0x4a5a22);
+  // eyes (yellow menace)
+  g.rect(6, 5, 1, 1).fill(0xe8c038);
+  g.rect(9, 5, 1, 1).fill(0xe8c038);
+  // tusks
+  g.rect(7, 6, 1, 1).fill(0xf0f0d6);
+  g.rect(8, 6, 1, 1).fill(0xf0f0d6);
+  // torso — bulkier than goblin
+  g.rect(4, 7, 8, 5).fill(0x5a6a2a);
+  // belt
+  g.rect(4, 11, 8, 1).fill(0x3a2414);
+  // arms
+  g.rect(3, 8, 1, 4).fill(0x6a7a3a);
+  g.rect(12, 8, 1, 4).fill(0x6a7a3a);
+  // legs
+  g.rect(5, 12, 2, 3).fill(0x3a4a1a);
+  g.rect(9, 12, 2, 3).fill(0x3a4a1a);
+  // feet
+  g.rect(4, 14, 3, 1).fill(0x1a1408);
+  g.rect(9, 14, 3, 1).fill(0x1a1408);
+  // axe (left hand)
+  g.rect(2, 4, 1, 6).fill(0x8a5a1a);
+  g.rect(0, 4, 3, 2).fill(0x8a8a98);
+  g.rect(0, 4, 1, 1).fill(0xc0c0d0);
+}
+
+function drawTroll(g: Graphics): void {
+  // BOSS unit — fills almost the whole tile, mossy and hulking.
+  // massive body
+  g.rect(3, 4, 10, 10).fill(0x3a6a3a);
+  // shoulder/back highlight
+  g.rect(3, 4, 10, 1).fill(0x5a8a4a);
+  // head / lumpy skull
+  g.rect(5, 1, 6, 4).fill(0x4a7a4a);
+  g.rect(4, 2, 1, 2).fill(0x4a7a4a);
+  g.rect(11, 2, 1, 2).fill(0x4a7a4a);
+  // single horn
+  g.rect(7, 0, 2, 1).fill(0xe8d8a8);
+  // glowing orange eyes
+  g.rect(6, 3, 1, 1).fill(0xf06020);
+  g.rect(9, 3, 1, 1).fill(0xf06020);
+  // gnarled jaw
+  g.rect(6, 4, 4, 1).fill(0x2a4a2a);
+  g.rect(7, 4, 1, 1).fill(0xf0f0d6);
+  g.rect(8, 4, 1, 1).fill(0xf0f0d6);
+  // arms — thick and long
+  g.rect(1, 6, 2, 6).fill(0x3a6a3a);
+  g.rect(13, 6, 2, 6).fill(0x3a6a3a);
+  // fists / claws
+  g.rect(1, 12, 2, 1).fill(0x1a1a08);
+  g.rect(13, 12, 2, 1).fill(0x1a1a08);
+  // moss/scars speckles
+  g.rect(5, 7, 1, 1).fill(0x7a9a4a);
+  g.rect(10, 8, 1, 1).fill(0x7a9a4a);
+  g.rect(7, 10, 1, 1).fill(0x2a4a1a);
+  // legs / feet
+  g.rect(4, 14, 3, 1).fill(0x1a2a08);
+  g.rect(9, 14, 3, 1).fill(0x1a2a08);
 }

--- a/simple-roguelike/src/style.css
+++ b/simple-roguelike/src/style.css
@@ -72,12 +72,60 @@ h1 {
   width: 100%;
   max-width: 768px;
   display: flex;
-  gap: 10px;
-  justify-content: center;
+  gap: 16px;
+  justify-content: space-between;
+  align-items: center;
+}
+
+/* D-pad: 3×3 grid with arrows in a cross and Confirm at the center. */
+#dpad {
+  display: grid;
+  grid-template-columns: repeat(3, 52px);
+  grid-template-rows: repeat(3, 52px);
+  gap: 4px;
+  flex: 0 0 auto;
+}
+
+.dpad-btn {
+  padding: 0;
+  min-height: 0;
+  background: var(--panel);
+  color: var(--accent);
+  border: 1px solid var(--panel-border);
+  border-radius: 6px;
+  font: inherit;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.dpad-btn:hover {
+  border-color: var(--accent);
+}
+
+.dpad-btn:active {
+  background: #1f1f2c;
+}
+
+.dpad-up      { grid-column: 2; grid-row: 1; }
+.dpad-left    { grid-column: 1; grid-row: 2; }
+.dpad-confirm { grid-column: 2; grid-row: 2; font-size: 14px; letter-spacing: 0.08em; color: #f0e0a8; }
+.dpad-right   { grid-column: 3; grid-row: 2; }
+.dpad-down    { grid-column: 2; grid-row: 3; }
+
+#actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1 1 0;
+  min-width: 0;
 }
 
 .ctrl-btn {
-  flex: 1 1 0;
   /* ≥ 44 px tap target per Apple HIG / WCAG. */
   min-height: 48px;
   padding: 10px 16px;
@@ -148,18 +196,31 @@ kbd {
   font: inherit;
 }
 
-/* Narrow phones — tighten padding and shrink the header. */
+/* Narrow phones — tighten padding, shrink the header, make the canvas edge-to-edge. */
 @media (max-width: 480px) {
   #app {
+    /* Zero horizontal padding so the canvas can span the full viewport width.
+     * Inner content blocks (HUD, controls, help) restore their own padding below. */
+    padding-left: 0;
+    padding-right: 0;
+    gap: 8px;
+  }
+  h1, #hud, #controls, .help {
     padding-left: max(8px, env(safe-area-inset-left));
     padding-right: max(8px, env(safe-area-inset-right));
-    gap: 8px;
+    width: 100%;
+    box-sizing: border-box;
   }
   h1 {
     font-size: 16px;
+    text-align: center;
   }
   #game {
-    max-width: 100%;
+    /* Canvas fills the full phone width, flush with the screen edges. */
+    width: 100vw;
+    max-width: 100vw;
+    border-left: none;
+    border-right: none;
   }
   .help {
     font-size: 11px;
@@ -167,5 +228,13 @@ kbd {
   #log {
     min-height: 72px;
     font-size: 12px;
+  }
+  /* Slightly smaller D-pad so both the pad and Restart fit on narrow phones. */
+  #dpad {
+    grid-template-columns: repeat(3, 48px);
+    grid-template-rows: repeat(3, 48px);
+  }
+  .dpad-confirm {
+    font-size: 13px;
   }
 }

--- a/simple-roguelike/tests/enemies.test.ts
+++ b/simple-roguelike/tests/enemies.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { World } from "../src/game/world";
+import { TileMap } from "../src/game/map/tilemap";
+import { Tile } from "../src/game/map/tiles";
+import {
+  spawnGoblin,
+  spawnOrc,
+  spawnRat,
+  spawnTroll,
+} from "../src/game/entities/factories";
+import { wanderStep } from "../src/game/systems/ai";
+import { MessageLog } from "../src/ui/hud";
+import type { Rng } from "../src/game/rng";
+
+/** Build an all-floor map of given size for wander tests. */
+function openMap(w = 5, h = 5): TileMap {
+  const map = new TileMap(w, h, Tile.Floor);
+  return map;
+}
+
+/** A deterministic RNG that yields the given numbers in order, then repeats the last. */
+function scriptedRng(values: number[]): Rng {
+  let i = 0;
+  return () => {
+    const v = values[Math.min(i, values.length - 1)];
+    i++;
+    return v;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Enemy factories
+// ---------------------------------------------------------------------------
+
+describe("enemy factories", () => {
+  it("spawnRat sets the low-tier stat block", () => {
+    const world = new World();
+    const id = spawnRat(world, 3, 4);
+    const c = world.get(id)!;
+    expect(c.renderable?.sprite).toBe("rat");
+    expect(c.health).toEqual({ hp: 3, max: 3 });
+    expect(c.stats).toEqual({ str: 0, def: 0 });
+    expect(c.combat?.damageDice).toEqual([1, 2]);
+    expect(c.xpReward).toBe(1);
+    expect(c.ai).toEqual({ kind: "hostile", hasSeenPlayer: false });
+    expect(c.blocker).toBe(true);
+    expect(c.position).toEqual({ x: 3, y: 4 });
+  });
+
+  it("spawnGoblin still matches its original stat block", () => {
+    const world = new World();
+    const id = spawnGoblin(world, 0, 0);
+    const c = world.get(id)!;
+    expect(c.renderable?.sprite).toBe("goblin");
+    expect(c.health).toEqual({ hp: 5, max: 5 });
+    expect(c.stats).toEqual({ str: 0, def: 0 });
+    expect(c.combat?.damageDice).toEqual([1, 3]);
+    expect(c.xpReward).toBe(3);
+  });
+
+  it("spawnOrc is a mid-tier threat", () => {
+    const world = new World();
+    const id = spawnOrc(world, 0, 0);
+    const c = world.get(id)!;
+    expect(c.renderable?.sprite).toBe("orc");
+    expect(c.health).toEqual({ hp: 9, max: 9 });
+    expect(c.stats).toEqual({ str: 2, def: 1 });
+    expect(c.combat?.damageDice).toEqual([1, 4]);
+    expect(c.xpReward).toBe(6);
+  });
+
+  it("spawnTroll is the boss tier", () => {
+    const world = new World();
+    const id = spawnTroll(world, 0, 0);
+    const c = world.get(id)!;
+    expect(c.renderable?.sprite).toBe("troll");
+    expect(c.health).toEqual({ hp: 18, max: 18 });
+    expect(c.stats).toEqual({ str: 4, def: 2 });
+    expect(c.combat?.damageDice).toEqual([2, 4]);
+    expect(c.xpReward).toBe(15);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wander behavior
+// ---------------------------------------------------------------------------
+
+describe("wanderStep", () => {
+  it("idles (returns null) when the idle roll hits", () => {
+    const world = new World();
+    const map = openMap();
+    const log = new MessageLog();
+    const id = spawnRat(world, 2, 2);
+    // rng() < 0.5 → idle
+    const step = wanderStep(world, map, id, scriptedRng([0.1]), log);
+    expect(step).toBeNull();
+    expect(world.get(id)!.position).toEqual({ x: 2, y: 2 });
+  });
+
+  it("moves one tile when the idle roll misses and a direction is open", () => {
+    const world = new World();
+    const map = openMap();
+    const log = new MessageLog();
+    const id = spawnRat(world, 2, 2);
+    // First rng() ≥ 0.5 → don't idle.
+    // Second rng() = 0 → randInt picks index 0 → direction [-1, -1].
+    const step = wanderStep(world, map, id, scriptedRng([0.9, 0]), log);
+    expect(step).toEqual([-1, -1]);
+    expect(world.get(id)!.position).toEqual({ x: 1, y: 1 });
+  });
+
+  it("does not move when the chosen direction is blocked by a wall", () => {
+    const world = new World();
+    const map = new TileMap(5, 5, Tile.Floor);
+    // Surround (0,0) so index 0 direction (-1,-1) walks into an out-of-bounds wall.
+    const log = new MessageLog();
+    const id = spawnRat(world, 0, 0);
+    const step = wanderStep(world, map, id, scriptedRng([0.9, 0]), log);
+    expect(step).toBeNull();
+    expect(world.get(id)!.position).toEqual({ x: 0, y: 0 });
+  });
+
+  it("does not move when blocked by another entity", () => {
+    const world = new World();
+    const map = openMap();
+    const log = new MessageLog();
+    const id = spawnRat(world, 2, 2);
+    spawnGoblin(world, 1, 1); // blocker at (1, 1)
+    // direction index 0 → [-1, -1] which would step onto the goblin
+    const step = wanderStep(world, map, id, scriptedRng([0.9, 0]), log);
+    expect(step).toBeNull();
+    expect(world.get(id)!.position).toEqual({ x: 2, y: 2 });
+  });
+});


### PR DESCRIPTION
## Summary

Two stacked commits that together turn simple-roguelike from a flat bump-to-attack demo into a small but complete playable loop:

### 1. STR / DEF / HP stat system (d02cc09)
- New ECS components: `stats { str, def }`, `experience { xp, level }`, `xpReward`
- Damage formula: `max(1, diceRoll + attacker.STR − target.DEF)` (floors at 1 to avoid stalemates)
- Killing enemies grants XP; level-up gives +1 STR / +1 DEF / +3 max HP (and heals 3)
- HUD shows `HP · STR · DEF · Lv (xp/next) · Seed`

### 2. Enemy variety + wander AI + mobile D-pad (5f95f90)
- **Enemy exploration**: idle enemies now 8-way random-drift (50% idle chance per turn). Chase kicks in on first sight.
- **Enemy variety**: new **Rat** (HP 3 / 1d2 / xp 1), **Orc** (HP 9 / 1d4 / STR 2 / DEF 1 / xp 6), **Troll** (HP 18 / 2d4 / STR 4 / DEF 2 / xp 15). Spawn mix: troll → farthest room (boss lair), other rooms weighted rat/goblin/orc.
- **Mobile UI**: canvas goes edge-to-edge on ≤480px phones; new 3×3 D-pad with context-aware **OK** button (confirms stairs → escape, restarts on game over, else waits). Restart stays as a separate action.

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx vitest run` — 38 / 38 tests pass (14 new combat + 8 new enemies + 16 existing)
- [x] `npx vite build` — production build succeeds
- [ ] Load on desktop, play a full run: verify STR/DEF/XP display, level-up feedback, all four enemy sprites render
- [ ] Open on a phone: verify canvas fills the screen width, D-pad moves the player, OK waits / confirms stairs / restarts after death
- [ ] Reproducibility: `?seed=123` yields an identical run before and after on both commits

https://claude.ai/code/session_01LdfXkfjPG5FCcGPMEpy2Ny