### PR TITLE
Ship shape-shift vertical slice: combat + waves + draft + endgame

### DIFF
--- a/shape-shift/index.html
+++ b/shape-shift/index.html
@@ -14,11 +14,18 @@
   </head>
   <body>
     <main id="app">
-      <div id="game"></div>
-      <div id="hud">
-        <span id="seed-label">seed: -</span>
-        <button type="button" id="btn-restart" aria-label="Restart run">restart</button>
+      <header id="topbar">
+        <span id="hud-hp" class="hud-chip">HP: -</span>
+        <span id="hud-wave" class="hud-chip">W: -/-</span>
+        <span id="hud-seed" class="hud-chip" aria-label="run seed">seed: -</span>
+        <button type="button" id="btn-restart" class="ctrl-btn" aria-label="Restart run">↻</button>
+      </header>
+      <div id="game">
+        <div id="overlay" hidden>
+          <div id="overlay-inner"></div>
+        </div>
       </div>
+      <footer id="footer-hint">drag anywhere to move · shots are automatic</footer>
     </main>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/shape-shift/src/game/cards.ts
+++ b/shape-shift/src/game/cards.ts
@@ -1,0 +1,62 @@
+import { type Rng, shuffle } from "./rng";
+import type { World, EntityId } from "./world";
+
+// MVP card pool: 10 cards that affect avatar stats or the single starting
+// weapon. Effects are data; apply() interprets them. No per-card logic.
+
+export type Rarity = "common" | "uncommon" | "rare";
+
+export type CardEffect =
+  | { kind: "damageAdd"; value: number }
+  | { kind: "periodMul"; value: number }      // < 1 = faster fire
+  | { kind: "projectileSpeedMul"; value: number }
+  | { kind: "projectilesAdd"; value: number }
+  | { kind: "pierceAdd"; value: number }
+  | { kind: "critAdd"; value: number }         // 0..1
+  | { kind: "maxHpAdd"; value: number }
+  | { kind: "speedMul"; value: number };
+
+export interface Card {
+  id: string;
+  name: string;
+  glyph: string;    // single-char symbol rendered as the art
+  rarity: Rarity;
+  text: string;
+  effect: CardEffect;
+}
+
+export const POOL: readonly Card[] = [
+  { id: "sharp",      name: "Sharp Edge",    glyph: "△", rarity: "common",   text: "+1 damage",              effect: { kind: "damageAdd", value: 1 } },
+  { id: "rapid",      name: "Rapid Fire",    glyph: "⟫", rarity: "common",   text: "-20% fire interval",     effect: { kind: "periodMul", value: 0.8 } },
+  { id: "velocity",   name: "Velocity",      glyph: "→", rarity: "common",   text: "+25% projectile speed",  effect: { kind: "projectileSpeedMul", value: 1.25 } },
+  { id: "fork",       name: "Fork",          glyph: "⋔", rarity: "uncommon", text: "+1 projectile",          effect: { kind: "projectilesAdd", value: 1 } },
+  { id: "pierce",     name: "Pierce",        glyph: "◇", rarity: "uncommon", text: "+1 pierce",              effect: { kind: "pierceAdd", value: 1 } },
+  { id: "crit",       name: "Crit",          glyph: "✦", rarity: "uncommon", text: "+25% crit chance",       effect: { kind: "critAdd", value: 0.25 } },
+  { id: "plating",    name: "Plating",       glyph: "▢", rarity: "common",   text: "+1 max HP",              effect: { kind: "maxHpAdd", value: 1 } },
+  { id: "dash",       name: "Dash",          glyph: "≫", rarity: "common",   text: "+20% move speed",        effect: { kind: "speedMul", value: 1.2 } },
+  { id: "overclock",  name: "Overclock",     glyph: "◎", rarity: "rare",     text: "-35% fire interval",     effect: { kind: "periodMul", value: 0.65 } },
+  { id: "heavy",      name: "Heavy Rounds",  glyph: "■", rarity: "rare",     text: "+2 damage",              effect: { kind: "damageAdd", value: 2 } },
+];
+
+export function drawOffer(rng: Rng, count: number, pool: readonly Card[] = POOL): Card[] {
+  return shuffle(rng, pool).slice(0, Math.min(count, pool.length));
+}
+
+export function applyCard(world: World, avatarId: EntityId, card: Card): void {
+  const c = world.get(avatarId);
+  if (!c || !c.avatar || !c.weapon) return;
+  const e = card.effect;
+  switch (e.kind) {
+    case "damageAdd":          c.weapon.damage += e.value; break;
+    case "periodMul":          c.weapon.period = Math.max(0.05, c.weapon.period * e.value); break;
+    case "projectileSpeedMul": c.weapon.projectileSpeed *= e.value; break;
+    case "projectilesAdd":     c.weapon.projectiles += e.value; break;
+    case "pierceAdd":          c.weapon.pierce += e.value; break;
+    case "critAdd":            c.weapon.crit = Math.min(1, c.weapon.crit + e.value); break;
+    case "maxHpAdd":
+      c.avatar.maxHp += e.value;
+      c.avatar.hp = Math.min(c.avatar.maxHp, c.avatar.hp + e.value);
+      break;
+    case "speedMul":           c.avatar.speedMul *= e.value; break;
+  }
+}

--- a/shape-shift/src/game/config.ts
+++ b/shape-shift/src/game/config.ts
@@ -1,0 +1,33 @@
+// Play-field is a 9:16 rectangle in internal pixels. All gameplay math uses
+// these coords; CSS scales the canvas to the viewport.
+export const PLAY_W = 360;
+export const PLAY_H = 640;
+
+// Avatar
+export const AVATAR_START_X = PLAY_W / 2;
+export const AVATAR_START_Y = PLAY_H * 0.75;
+export const AVATAR_BASE_SPEED = 260; // play-field px / s
+export const AVATAR_RADIUS = 10;
+export const AVATAR_BASE_HP = 3;
+export const AVATAR_IFRAMES = 0.6; // seconds of invulnerability after a hit
+
+// Weapon (Vertex Shot — starting weapon)
+export const WEAPON_BASE_PERIOD = 0.55; // seconds between shots
+export const WEAPON_BASE_DAMAGE = 1;
+export const WEAPON_BASE_PROJECTILE_SPEED = 520;
+export const WEAPON_BASE_PIERCE = 0;
+export const WEAPON_BASE_PROJECTILES = 1;
+export const WEAPON_BASE_CRIT = 0;
+
+export const PROJECTILE_RADIUS = 4;
+
+// Enemies
+export const ENEMY_SPAWN_MARGIN = 24; // spawn just outside this inset from edges
+export const ENEMY_SEEK_ACCEL = 1400; // how fast enemies reach their max speed
+
+// Fixed-step sim
+export const FIXED_DT = 1 / 60;
+export const MAX_FRAME = 0.1;
+
+// Hit flash (seconds)
+export const HIT_FLASH_TIME = 0.1;

--- a/shape-shift/src/game/entities.ts
+++ b/shape-shift/src/game/entities.ts
@@ -1,0 +1,114 @@
+import {
+  AVATAR_BASE_HP,
+  AVATAR_RADIUS,
+  AVATAR_START_X,
+  AVATAR_START_Y,
+  ENEMY_SPAWN_MARGIN,
+  PLAY_H,
+  PLAY_W,
+  PROJECTILE_RADIUS,
+  WEAPON_BASE_CRIT,
+  WEAPON_BASE_DAMAGE,
+  WEAPON_BASE_PIERCE,
+  WEAPON_BASE_PERIOD,
+  WEAPON_BASE_PROJECTILES,
+  WEAPON_BASE_PROJECTILE_SPEED,
+} from "./config";
+import { type Rng } from "./rng";
+import { type EnemyKind, type EntityId, type WeaponState, World } from "./world";
+
+export function spawnAvatar(world: World): EntityId {
+  return world.create({
+    pos: { x: AVATAR_START_X, y: AVATAR_START_Y },
+    vel: { x: 0, y: 0 },
+    radius: AVATAR_RADIUS,
+    team: "player",
+    avatar: {
+      hp: AVATAR_BASE_HP,
+      maxHp: AVATAR_BASE_HP,
+      speedMul: 1,
+      iframes: 0,
+      targetX: AVATAR_START_X,
+      targetY: AVATAR_START_Y,
+    },
+    weapon: {
+      period: WEAPON_BASE_PERIOD,
+      damage: WEAPON_BASE_DAMAGE,
+      projectileSpeed: WEAPON_BASE_PROJECTILE_SPEED,
+      projectiles: WEAPON_BASE_PROJECTILES,
+      pierce: WEAPON_BASE_PIERCE,
+      crit: WEAPON_BASE_CRIT,
+      cooldown: 0.2, // tiny grace before first shot
+    },
+  });
+}
+
+export interface EnemyStats {
+  hp: number;
+  maxSpeed: number;
+  contactDamage: number;
+  radius: number;
+}
+
+const ENEMY_STATS: Record<EnemyKind, EnemyStats> = {
+  circle:  { hp: 2,  maxSpeed: 70,  contactDamage: 1, radius: 8 },
+  square:  { hp: 3,  maxSpeed: 95,  contactDamage: 1, radius: 9 },
+  star:    { hp: 6,  maxSpeed: 85,  contactDamage: 1, radius: 11 },
+  boss:    { hp: 60, maxSpeed: 50,  contactDamage: 1, radius: 22 },
+};
+
+export function spawnEnemy(world: World, kind: EnemyKind, rng: Rng): EntityId {
+  const stats = ENEMY_STATS[kind];
+  // Bosses appear in the upper play-field, centered. Other enemies spawn on
+  // the outer margin of one of the four edges.
+  let x: number, y: number;
+  if (kind === "boss") {
+    x = PLAY_W / 2;
+    y = PLAY_H * 0.15;
+  } else {
+    const edge = Math.floor(rng() * 4);
+    if (edge === 0)        { x = rng() * PLAY_W; y = ENEMY_SPAWN_MARGIN; }
+    else if (edge === 1)   { x = PLAY_W - ENEMY_SPAWN_MARGIN; y = rng() * PLAY_H; }
+    else if (edge === 2)   { x = rng() * PLAY_W; y = PLAY_H - ENEMY_SPAWN_MARGIN; }
+    else                   { x = ENEMY_SPAWN_MARGIN; y = rng() * PLAY_H; }
+  }
+  return world.create({
+    pos: { x, y },
+    vel: { x: 0, y: 0 },
+    radius: stats.radius,
+    team: "enemy",
+    enemy: {
+      kind,
+      contactDamage: stats.contactDamage,
+      maxSpeed: stats.maxSpeed,
+      wobblePhase: rng() * Math.PI * 2,
+    },
+    hp: { value: stats.hp },
+  });
+}
+
+export function spawnProjectile(
+  world: World,
+  ownerId: EntityId,
+  x: number,
+  y: number,
+  vx: number,
+  vy: number,
+  weapon: WeaponState,
+  crit: boolean,
+): EntityId {
+  return world.create({
+    pos: { x, y },
+    vel: { x: vx, y: vy },
+    radius: PROJECTILE_RADIUS,
+    team: "projectile",
+    projectile: {
+      ownerId,
+      damage: weapon.damage * (crit ? 2 : 1),
+      crit,
+      pierceRemaining: weapon.pierce,
+      hitIds: new Set<EntityId>(),
+      ttl: 1.6, // seconds
+    },
+  });
+}

--- a/shape-shift/src/game/loop.ts
+++ b/shape-shift/src/game/loop.ts
@@ -1,0 +1,36 @@
+import { FIXED_DT, MAX_FRAME } from "./config";
+
+// Fixed-timestep accumulator (Gaffer-on-Games pattern). The sim always runs at
+// FIXED_DT regardless of frame rate; render is called once per rAF with alpha
+// for interpolation if needed. Clamp huge deltas so tab-switches don't spiral.
+
+export interface LoopHandle { stop: () => void }
+
+export function startLoop(
+  update: (dt: number) => void,
+  render: (alpha: number) => void,
+): LoopHandle {
+  let last = performance.now() / 1000;
+  let acc = 0;
+  let running = true;
+
+  function frame(nowMs: number): void {
+    if (!running) return;
+    const t = nowMs / 1000;
+    let delta = t - last;
+    if (delta > MAX_FRAME) delta = MAX_FRAME;
+    last = t;
+    acc += delta;
+    while (acc >= FIXED_DT) {
+      update(FIXED_DT);
+      acc -= FIXED_DT;
+    }
+    render(acc / FIXED_DT);
+    requestAnimationFrame(frame);
+  }
+  requestAnimationFrame(frame);
+
+  return {
+    stop() { running = false; },
+  };
+}

--- a/shape-shift/src/game/systems/ai.ts
+++ b/shape-shift/src/game/systems/ai.ts
@@ -1,0 +1,52 @@
+import { ENEMY_SEEK_ACCEL } from "../config";
+import type { EntityId, World } from "../world";
+
+// Enemies seek the avatar. Circle/square go straight; star adds lateral wobble;
+// boss moves slowly with the same seek. All use accel-capped steering so they
+// don't teleport and feel bouncy when knocked off path.
+
+export function updateEnemyAi(world: World, avatarId: EntityId, dt: number): void {
+  const avatar = world.get(avatarId);
+  if (!avatar || !avatar.pos) return;
+  const ax = avatar.pos.x;
+  const ay = avatar.pos.y;
+  for (const [, c] of world.with("enemy", "pos", "vel")) {
+    const p = c.pos!;
+    const v = c.vel!;
+    const e = c.enemy!;
+
+    let dx = ax - p.x;
+    let dy = ay - p.y;
+    const dist = Math.hypot(dx, dy) || 1;
+    let nx = dx / dist;
+    let ny = dy / dist;
+
+    if (e.kind === "star") {
+      // Lateral wobble: perpendicular sine added to direction.
+      e.wobblePhase += dt * 3.2;
+      const wob = Math.sin(e.wobblePhase) * 0.7;
+      const px = -ny;
+      const py = nx;
+      nx += px * wob;
+      ny += py * wob;
+      const len = Math.hypot(nx, ny) || 1;
+      nx /= len; ny /= len;
+    }
+
+    const targetVx = nx * e.maxSpeed;
+    const targetVy = ny * e.maxSpeed;
+    const dvx = targetVx - v.x;
+    const dvy = targetVy - v.y;
+    const dvLen = Math.hypot(dvx, dvy);
+    const maxStep = ENEMY_SEEK_ACCEL * dt;
+    if (dvLen <= maxStep) {
+      v.x = targetVx;
+      v.y = targetVy;
+    } else {
+      v.x += (dvx / dvLen) * maxStep;
+      v.y += (dvy / dvLen) * maxStep;
+    }
+    p.x += v.x * dt;
+    p.y += v.y * dt;
+  }
+}

--- a/shape-shift/src/game/systems/collision.ts
+++ b/shape-shift/src/game/systems/collision.ts
@@ -1,0 +1,83 @@
+import { AVATAR_IFRAMES, HIT_FLASH_TIME } from "../config";
+import type { EntityId, World } from "../world";
+
+// Circle-circle collision. Enough for the visual language of the game.
+// Scope: ~40 enemies × ~100 projectiles = 4000 checks/frame — negligible.
+
+export interface CombatEvents {
+  onEnemyKilled?: (id: EntityId) => void;
+  onPlayerHit?: (amount: number) => void;
+  onPlayerDied?: () => void;
+}
+
+export function updateCollisions(
+  world: World,
+  avatarId: EntityId,
+  events: CombatEvents,
+): void {
+  // Projectile vs enemy.
+  for (const [pid, pc] of world.with("projectile", "pos", "radius")) {
+    const proj = pc.projectile!;
+    if (proj.pierceRemaining < -1) { world.remove(pid); continue; }
+    const pr = pc.radius!;
+    const px = pc.pos!.x;
+    const py = pc.pos!.y;
+    for (const [eid, ec] of world.with("enemy", "pos", "radius", "hp")) {
+      if (ec.hp!.value <= 0) continue;
+      if (proj.hitIds.has(eid)) continue;
+      const er = ec.radius!;
+      const dx = ec.pos!.x - px;
+      const dy = ec.pos!.y - py;
+      const rr = (pr + er);
+      if (dx * dx + dy * dy > rr * rr) continue;
+      ec.hp!.value -= proj.damage;
+      ec.flash = HIT_FLASH_TIME;
+      proj.hitIds.add(eid);
+      if (proj.pierceRemaining > 0) {
+        proj.pierceRemaining -= 1;
+      } else {
+        world.remove(pid);
+      }
+      if (ec.hp!.value <= 0) {
+        ec.dead = true;
+        events.onEnemyKilled?.(eid);
+      }
+      break; // one hit per projectile step
+    }
+  }
+
+  // Enemy vs avatar (contact damage).
+  const avatar = world.get(avatarId);
+  if (!avatar || !avatar.avatar || !avatar.pos) return;
+  const a = avatar.avatar;
+  if (a.hp <= 0) return;
+  const ar = avatar.radius ?? 10;
+  const ax = avatar.pos.x;
+  const ay = avatar.pos.y;
+  for (const [, ec] of world.with("enemy", "pos", "radius", "hp")) {
+    if (ec.hp!.value <= 0) continue;
+    const er = ec.radius!;
+    const dx = ec.pos!.x - ax;
+    const dy = ec.pos!.y - ay;
+    const rr = ar + er;
+    if (dx * dx + dy * dy > rr * rr) continue;
+    if (a.iframes > 0) continue;
+    const dmg = ec.enemy!.contactDamage;
+    a.hp -= dmg;
+    a.iframes = AVATAR_IFRAMES;
+    avatar.flash = HIT_FLASH_TIME;
+    events.onPlayerHit?.(dmg);
+    if (a.hp <= 0) {
+      a.hp = 0;
+      events.onPlayerDied?.();
+    }
+    break;
+  }
+}
+
+// Sweep dead enemies once per step.
+export function removeDeadEnemies(world: World): void {
+  for (const [id, c] of world.with("enemy")) {
+    if (c.dead || (c.hp?.value ?? 1) <= 0) world.remove(id);
+  }
+}

--- a/shape-shift/src/game/systems/motion.ts
+++ b/shape-shift/src/game/systems/motion.ts
@@ -1,0 +1,58 @@
+import { AVATAR_BASE_SPEED, PLAY_H, PLAY_W } from "../config";
+import type { World } from "../world";
+
+export function updateAvatarMotion(world: World, dt: number): void {
+  for (const [, c] of world.with("avatar", "pos", "vel")) {
+    const a = c.avatar!;
+    const p = c.pos!;
+    // Glide toward target at capped speed. No acceleration — it feels snappy
+    // on mobile drag.
+    const dx = a.targetX - p.x;
+    const dy = a.targetY - p.y;
+    const dist = Math.hypot(dx, dy);
+    const maxStep = AVATAR_BASE_SPEED * a.speedMul * dt;
+    if (dist <= maxStep || dist < 0.1) {
+      p.x = a.targetX;
+      p.y = a.targetY;
+      c.vel!.x = 0;
+      c.vel!.y = 0;
+    } else {
+      const nx = dx / dist;
+      const ny = dy / dist;
+      p.x += nx * maxStep;
+      p.y += ny * maxStep;
+      c.vel!.x = nx * AVATAR_BASE_SPEED * a.speedMul;
+      c.vel!.y = ny * AVATAR_BASE_SPEED * a.speedMul;
+    }
+    // Keep avatar inside play-field.
+    if (p.x < 0) p.x = 0;
+    if (p.x > PLAY_W) p.x = PLAY_W;
+    if (p.y < 0) p.y = 0;
+    if (p.y > PLAY_H) p.y = PLAY_H;
+    if (a.iframes > 0) a.iframes = Math.max(0, a.iframes - dt);
+  }
+}
+
+export function updateProjectileMotion(world: World, dt: number): void {
+  for (const [id, c] of world.with("projectile", "pos", "vel")) {
+    c.pos!.x += c.vel!.x * dt;
+    c.pos!.y += c.vel!.y * dt;
+    c.projectile!.ttl -= dt;
+    // Despawn if out of bounds or timed out.
+    if (
+      c.projectile!.ttl <= 0 ||
+      c.pos!.x < -20 || c.pos!.x > PLAY_W + 20 ||
+      c.pos!.y < -20 || c.pos!.y > PLAY_H + 20
+    ) {
+      world.remove(id);
+    }
+  }
+}
+
+export function decayHitFlash(world: World, dt: number): void {
+  for (const [, c] of world.entities) {
+    if (c.flash !== undefined && c.flash > 0) {
+      c.flash = Math.max(0, c.flash - dt);
+    }
+  }
+}

--- a/shape-shift/src/game/systems/wave.ts
+++ b/shape-shift/src/game/systems/wave.ts
@@ -1,0 +1,37 @@
+import { spawnEnemy } from "../entities";
+import type { Rng } from "../rng";
+import { type WaveSpec } from "../waves";
+import type { World } from "../world";
+
+// Wave runner: advances a timer, fires scheduled spawn groups, and reports
+// when the wave is "cleared" (all groups fired AND no live enemies remain).
+
+export interface WaveState {
+  spec: WaveSpec;
+  elapsed: number;
+  nextGroupIdx: number;
+  cleared: boolean;
+}
+
+export function newWaveState(spec: WaveSpec): WaveState {
+  return { spec, elapsed: 0, nextGroupIdx: 0, cleared: false };
+}
+
+export function updateWave(state: WaveState, world: World, rng: Rng, dt: number): void {
+  if (state.cleared) return;
+  state.elapsed += dt;
+  while (state.nextGroupIdx < state.spec.groups.length) {
+    const g = state.spec.groups[state.nextGroupIdx]!;
+    if (state.elapsed < g.t) break;
+    for (let i = 0; i < g.count; i++) spawnEnemy(world, g.kind, rng);
+    state.nextGroupIdx += 1;
+  }
+  if (state.nextGroupIdx >= state.spec.groups.length) {
+    // All groups fired — check if any enemy remains.
+    let alive = false;
+    for (const [, c] of world.with("enemy", "hp")) {
+      if ((c.hp?.value ?? 0) > 0) { alive = true; break; }
+    }
+    if (!alive) state.cleared = true;
+  }
+}

--- a/shape-shift/src/game/systems/weapon.ts
+++ b/shape-shift/src/game/systems/weapon.ts
@@ -1,0 +1,59 @@
+import { spawnProjectile } from "../entities";
+import type { Rng } from "../rng";
+import type { EntityId, World } from "../world";
+
+// Auto-fire system: avatar's weapon cooldown ticks down; when ≤ 0, fire at
+// the closest living enemy. If `weapon.projectiles > 1`, fan the shots with
+// a small spread angle.
+
+const FAN_SPREAD = 0.25; // radians between adjacent projectiles in a fan
+
+function closestEnemy(world: World, x: number, y: number): EntityId | null {
+  let bestId: EntityId | null = null;
+  let bestDist = Infinity;
+  for (const [id, c] of world.with("enemy", "pos", "hp")) {
+    if ((c.hp!.value) <= 0) continue;
+    const dx = c.pos!.x - x;
+    const dy = c.pos!.y - y;
+    const d = dx * dx + dy * dy;
+    if (d < bestDist) {
+      bestDist = d;
+      bestId = id;
+    }
+  }
+  return bestId;
+}
+
+export function updateWeapon(
+  world: World,
+  avatarId: EntityId,
+  rng: Rng,
+  dt: number,
+): void {
+  const c = world.get(avatarId);
+  if (!c || !c.weapon || !c.pos) return;
+  const w = c.weapon;
+  w.cooldown -= dt;
+  if (w.cooldown > 0) return;
+
+  const targetId = closestEnemy(world, c.pos.x, c.pos.y);
+  if (targetId === null) {
+    // No target: don't overcharge cooldown forever.
+    if (w.cooldown < -0.5) w.cooldown = 0;
+    return;
+  }
+  const target = world.get(targetId)!;
+  const dx = target.pos!.x - c.pos.x;
+  const dy = target.pos!.y - c.pos.y;
+  const baseAngle = Math.atan2(dy, dx);
+  const n = Math.max(1, w.projectiles);
+  const startAngle = baseAngle - FAN_SPREAD * (n - 1) / 2;
+  for (let i = 0; i < n; i++) {
+    const a = startAngle + FAN_SPREAD * i;
+    const vx = Math.cos(a) * w.projectileSpeed;
+    const vy = Math.sin(a) * w.projectileSpeed;
+    const crit = rng() < w.crit;
+    spawnProjectile(world, avatarId, c.pos.x, c.pos.y, vx, vy, w, crit);
+  }
+  w.cooldown = w.period;
+}

--- a/shape-shift/src/game/waves.ts
+++ b/shape-shift/src/game/waves.ts
@@ -1,0 +1,93 @@
+import type { EnemyKind } from "./world";
+
+// Wave spec: each wave has a timeline of spawn groups. Each group fires at
+// `t` seconds after wave start. Wave ends when all groups are fired AND no
+// enemies remain alive. Boss waves simply schedule one boss.
+
+export interface SpawnGroup { t: number; kind: EnemyKind; count: number }
+export interface WaveSpec {
+  index: number;       // 1-based, for display
+  durationHint: number; // informational; real end is "all spawned + dead"
+  groups: SpawnGroup[];
+}
+
+export const WAVES: readonly WaveSpec[] = [
+  {
+    index: 1,
+    durationHint: 20,
+    groups: [
+      { t: 0.5, kind: "circle", count: 3 },
+      { t: 6,   kind: "circle", count: 4 },
+      { t: 12,  kind: "circle", count: 5 },
+    ],
+  },
+  {
+    index: 2,
+    durationHint: 22,
+    groups: [
+      { t: 0.5, kind: "circle", count: 5 },
+      { t: 7,   kind: "circle", count: 6 },
+      { t: 14,  kind: "square", count: 2 },
+    ],
+  },
+  {
+    index: 3,
+    durationHint: 24,
+    groups: [
+      { t: 0.5, kind: "circle", count: 4 },
+      { t: 5,   kind: "square", count: 3 },
+      { t: 12,  kind: "circle", count: 6 },
+      { t: 18,  kind: "square", count: 3 },
+    ],
+  },
+  {
+    index: 4,
+    durationHint: 26,
+    groups: [
+      { t: 0.5, kind: "square", count: 4 },
+      { t: 7,   kind: "circle", count: 6 },
+      { t: 14,  kind: "square", count: 4 },
+      { t: 20,  kind: "circle", count: 5 },
+    ],
+  },
+  {
+    index: 5,
+    durationHint: 28,
+    groups: [
+      { t: 0.5, kind: "circle", count: 6 },
+      { t: 6,   kind: "star",   count: 2 },
+      { t: 14,  kind: "square", count: 5 },
+      { t: 22,  kind: "star",   count: 2 },
+    ],
+  },
+  {
+    index: 6,
+    durationHint: 32,
+    groups: [
+      { t: 0.5, kind: "square", count: 5 },
+      { t: 6,   kind: "circle", count: 8 },
+      { t: 14,  kind: "star",   count: 3 },
+      { t: 22,  kind: "square", count: 6 },
+    ],
+  },
+  {
+    index: 7,
+    durationHint: 36,
+    groups: [
+      { t: 0.5, kind: "star",   count: 2 },
+      { t: 5,   kind: "circle", count: 8 },
+      { t: 12,  kind: "square", count: 6 },
+      { t: 20,  kind: "star",   count: 4 },
+      { t: 28,  kind: "circle", count: 8 },
+    ],
+  },
+  {
+    index: 8,
+    durationHint: 60,
+    groups: [
+      { t: 0.5, kind: "boss",   count: 1 },
+    ],
+  },
+];
+
+export const TOTAL_WAVES = WAVES.length;

--- a/shape-shift/src/game/world.ts
+++ b/shape-shift/src/game/world.ts
@@ -1,0 +1,94 @@
+// Plain bag-of-components World. Scope: ~250 simultaneous entities, so an
+// unindexed Map + linear iteration is more than enough. Keep all component
+// values as plain data so save/load is trivial later.
+
+export type EntityId = number;
+
+export type Team = "player" | "enemy" | "projectile";
+
+export type EnemyKind = "circle" | "square" | "star" | "boss";
+
+export interface Pos { x: number; y: number }
+export interface Vel { x: number; y: number }
+
+export interface WeaponState {
+  period: number;     // seconds between shots
+  damage: number;
+  projectileSpeed: number;
+  projectiles: number; // shots fired per trigger (spread fan if > 1)
+  pierce: number;     // projectile hits before despawn (0 = one hit)
+  crit: number;       // 0..1 crit chance for 2x damage
+  cooldown: number;   // seconds remaining until next shot
+}
+
+export interface Projectile {
+  ownerId: EntityId;
+  damage: number;
+  crit: boolean;
+  pierceRemaining: number;
+  hitIds: Set<EntityId>; // enemies already hit (so pierce doesn't re-hit)
+  ttl: number;
+}
+
+export interface Enemy {
+  kind: EnemyKind;
+  contactDamage: number;
+  maxSpeed: number;
+  wobblePhase: number;
+}
+
+export interface Avatar {
+  hp: number;
+  maxHp: number;
+  speedMul: number;
+  iframes: number;    // seconds of invulnerability remaining
+  targetX: number;
+  targetY: number;
+}
+
+export interface Components {
+  pos?: Pos;
+  vel?: Vel;
+  radius?: number;
+  team?: Team;
+  avatar?: Avatar;
+  weapon?: WeaponState;
+  enemy?: Enemy;
+  projectile?: Projectile;
+  hp?: { value: number }; // enemies only; avatar hp lives on Avatar
+  flash?: number;         // seconds of hit flash remaining
+  dead?: true;
+}
+
+export class World {
+  private nextId: EntityId = 1;
+  readonly entities = new Map<EntityId, Components>();
+
+  create(c: Components): EntityId {
+    const id = this.nextId++;
+    this.entities.set(id, c);
+    return id;
+  }
+
+  remove(id: EntityId): void {
+    this.entities.delete(id);
+  }
+
+  get(id: EntityId): Components | undefined {
+    return this.entities.get(id);
+  }
+
+  // Iterate entities that have all requested components. The returned map is
+  // the same reference as stored, so callers may mutate in place.
+  *with<K extends keyof Components>(...keys: K[]): Generator<[EntityId, Components]> {
+    outer: for (const [id, c] of this.entities) {
+      for (const k of keys) if (c[k] === undefined) continue outer;
+      yield [id, c];
+    }
+  }
+
+  clear(): void {
+    this.entities.clear();
+    this.nextId = 1;
+  }
+}

--- a/shape-shift/src/main.ts
+++ b/shape-shift/src/main.ts
@@ -1,107 +1,22 @@
 import "./style.css";
-import { Application, Container, Graphics } from "pixi.js";
+import { Application } from "pixi.js";
 
-import { createRng, pickSeed, type Rng } from "./game/rng";
-
-// Internal play-field resolution. 9:16 portrait. CSS letterboxes to any viewport.
-const PLAY_W = 360;
-const PLAY_H = 640;
-
-interface Game {
-  seed: number;
-  rng: Rng;
-  avatar: Graphics;
-  // target position the avatar is steering toward (in play-field coordinates).
-  targetX: number;
-  targetY: number;
-  // current avatar position (kept separately so we can ease toward target).
-  x: number;
-  y: number;
-}
-
-const AVATAR_SPEED = 360; // play-field pixels per second
-const AVATAR_SIZE = 18;
-
-function makeAvatar(): Graphics {
-  const g = new Graphics();
-  // Equilateral triangle pointing up, centered at (0, 0).
-  const r = AVATAR_SIZE;
-  const h = r * Math.sqrt(3) / 2;
-  g.moveTo(0, -h * 0.66);
-  g.lineTo(r * 0.5, h * 0.33);
-  g.lineTo(-r * 0.5, h * 0.33);
-  g.closePath();
-  g.fill({ color: 0x111111 });
-  return g;
-}
-
-function startRun(world: Container): Game {
-  const seed = pickSeed();
-  const rng = createRng(seed);
-  // eslint-disable-next-line no-console
-  console.log(`[shape-shift] run seed = ${seed}`);
-
-  const seedLabel = document.getElementById("seed-label");
-  if (seedLabel) seedLabel.textContent = `seed: ${seed}`;
-
-  world.removeChildren();
-  const avatar = makeAvatar();
-  const startX = PLAY_W / 2;
-  const startY = PLAY_H * 0.75;
-  avatar.position.set(startX, startY);
-  world.addChild(avatar);
-
-  return {
-    seed,
-    rng,
-    avatar,
-    targetX: startX,
-    targetY: startY,
-    x: startX,
-    y: startY,
-  };
-}
-
-function step(game: Game, dtSeconds: number): void {
-  const dx = game.targetX - game.x;
-  const dy = game.targetY - game.y;
-  const dist = Math.hypot(dx, dy);
-  if (dist < 0.5) return;
-  const maxStep = AVATAR_SPEED * dtSeconds;
-  const nx = dx / dist;
-  const ny = dy / dist;
-  const moveDist = Math.min(maxStep, dist);
-  game.x += nx * moveDist;
-  game.y += ny * moveDist;
-  game.avatar.position.set(game.x, game.y);
-}
-
-function fitCanvasToContainer(app: Application, container: HTMLElement): void {
-  const { clientWidth: cw, clientHeight: ch } = container;
-  if (cw === 0 || ch === 0) return;
-  // Letterbox: scale = min(cw / PLAY_W, ch / PLAY_H). Canvas CSS size stretches;
-  // internal renderer stays at PLAY_W × PLAY_H so gameplay coords are stable.
-  const scale = Math.min(cw / PLAY_W, ch / PLAY_H);
-  const displayW = Math.floor(PLAY_W * scale);
-  const displayH = Math.floor(PLAY_H * scale);
-  const canvas = app.canvas;
-  canvas.style.width = `${displayW}px`;
-  canvas.style.height = `${displayH}px`;
-}
-
-function clientToPlay(app: Application, clientX: number, clientY: number): { x: number; y: number } {
-  const rect = app.canvas.getBoundingClientRect();
-  const px = ((clientX - rect.left) / rect.width) * PLAY_W;
-  const py = ((clientY - rect.top) / rect.height) * PLAY_H;
-  return {
-    x: Math.max(0, Math.min(PLAY_W, px)),
-    y: Math.max(0, Math.min(PLAY_H, py)),
-  };
-}
+import { PLAY_H, PLAY_W } from "./game/config";
+import { startLoop } from "./game/loop";
+import { createRng, pickSeed } from "./game/rng";
+import { applyCard, drawOffer, type Card } from "./game/cards";
+import { DraftScene } from "./scenes/draft";
+import { EndgameScene } from "./scenes/endgame";
+import { PlayScene, type PointerMapper } from "./scenes/play";
+import { SceneStack } from "./scenes/scene";
 
 async function boot(): Promise<void> {
-  const container = document.getElementById("game");
-  if (!container) throw new Error("#game element missing");
+  const gameEl = document.getElementById("game");
+  const hudHp = document.getElementById("hud-hp");
+  const hudWave = document.getElementById("hud-wave");
+  const hudSeed = document.getElementById("hud-seed");
+  const btnRestart = document.getElementById("btn-restart");
+  if (!gameEl) throw new Error("#game element missing");
 
   const app = new Application();
   await app.init({
@@ -112,58 +27,97 @@ async function boot(): Promise<void> {
     autoDensity: true,
     resolution: window.devicePixelRatio || 1,
   });
-  container.appendChild(app.canvas);
+  gameEl.insertBefore(app.canvas, gameEl.firstChild);
 
-  const world = new Container();
-  app.stage.addChild(world);
+  const stack = new SceneStack();
+  // We swap the top-level Pixi stage to match whichever scene is on top. For
+  // overlay scenes (Draft/Endgame) the Play scene's root stays on stage so the
+  // frozen play-field remains visible.
+  // Implementation detail: each scene owns a Container; main merges them into
+  // app.stage as the stack changes.
+  const sceneLayer = app.stage;
 
-  let game = startRun(world);
-  fitCanvasToContainer(app, container);
-
-  window.addEventListener("resize", () => fitCanvasToContainer(app, container));
-
-  // Touch / pointer drag: while pressed, avatar target follows the pointer.
-  let tracking = false;
-  const onDown = (ev: PointerEvent) => {
-    tracking = true;
-    app.canvas.setPointerCapture?.(ev.pointerId);
-    const p = clientToPlay(app, ev.clientX, ev.clientY);
-    game.targetX = p.x;
-    game.targetY = p.y;
+  const mapper: PointerMapper = {
+    target: app.canvas,
+    clientToPlay: (clientX, clientY) => {
+      const rect = app.canvas.getBoundingClientRect();
+      const px = ((clientX - rect.left) / rect.width) * PLAY_W;
+      const py = ((clientY - rect.top) / rect.height) * PLAY_H;
+      return {
+        x: Math.max(0, Math.min(PLAY_W, px)),
+        y: Math.max(0, Math.min(PLAY_H, py)),
+      };
+    },
   };
-  const onMove = (ev: PointerEvent) => {
-    if (!tracking) return;
-    const p = clientToPlay(app, ev.clientX, ev.clientY);
-    game.targetX = p.x;
-    game.targetY = p.y;
-  };
-  const onUp = (ev: PointerEvent) => {
-    tracking = false;
-    app.canvas.releasePointerCapture?.(ev.pointerId);
-  };
-  app.canvas.addEventListener("pointerdown", onDown);
-  app.canvas.addEventListener("pointermove", onMove);
-  app.canvas.addEventListener("pointerup", onUp);
-  app.canvas.addEventListener("pointercancel", onUp);
 
-  // Keyboard fallback for desktop smoke-testing.
-  window.addEventListener("keydown", (ev) => {
-    const STEP = 24;
-    if (ev.key === "ArrowUp") game.targetY = Math.max(0, game.y - STEP);
-    else if (ev.key === "ArrowDown") game.targetY = Math.min(PLAY_H, game.y + STEP);
-    else if (ev.key === "ArrowLeft") game.targetX = Math.max(0, game.x - STEP);
-    else if (ev.key === "ArrowRight") game.targetX = Math.min(PLAY_W, game.x + STEP);
-    else if (ev.key === "r" || ev.key === "R") game = startRun(world);
-  });
+  // Canvas letterboxing: internal resolution is fixed at PLAY_W×PLAY_H. The
+  // CSS size is scaled to the largest 9:16 rectangle that fits in #game.
+  function fitCanvas(): void {
+    const { clientWidth: cw, clientHeight: ch } = gameEl!;
+    if (cw === 0 || ch === 0) return;
+    const scale = Math.min(cw / PLAY_W, ch / PLAY_H);
+    const w = Math.floor(PLAY_W * scale);
+    const h = Math.floor(PLAY_H * scale);
+    app.canvas.style.width = `${w}px`;
+    app.canvas.style.height = `${h}px`;
+  }
+  fitCanvas();
+  window.addEventListener("resize", fitCanvas);
 
-  document.getElementById("btn-restart")?.addEventListener("click", () => {
-    game = startRun(world);
-  });
+  let play: PlayScene;
+  let seed = 0;
 
-  app.ticker.add((ticker) => {
-    const dt = ticker.deltaMS / 1000;
-    step(game, dt);
-  });
+  function updateHud(hp: number, maxHp: number, waveIdx: number, totalWaves: number): void {
+    if (hudHp) hudHp.textContent = `HP: ${hp}/${maxHp}`;
+    if (hudWave) hudWave.textContent = `W: ${waveIdx}/${totalWaves}`;
+  }
+
+  function startNewRun(): void {
+    sceneLayer.removeChildren();
+    seed = pickSeed();
+    const rng = createRng(seed);
+    // eslint-disable-next-line no-console
+    console.log(`[shape-shift] run seed = ${seed}`);
+    if (hudSeed) hudSeed.textContent = `seed: ${seed}`;
+
+    play = new PlayScene(
+      rng,
+      {
+        updateHud,
+        onWaveCleared: (cleared) => {
+          const offer = drawOffer(rng, 3);
+          const label = `${cleared} of ${play.totalWaves()}`;
+          stack.push(new DraftScene(offer, label, (pick) => onPickCard(pick)));
+        },
+        onPlayerDied: () => {
+          stack.push(new EndgameScene("dead", play.currentWave1(), play.totalWaves(), startNewRun));
+        },
+        onRunWon: () => {
+          stack.push(new EndgameScene("won", play.totalWaves(), play.totalWaves(), startNewRun));
+        },
+      },
+      mapper,
+    );
+    sceneLayer.addChild(play.root);
+    // Clear existing stack (exit all current top scenes) before pushing play.
+    while (stack.top()) stack.pop();
+    stack.push(play);
+  }
+
+  function onPickCard(card: Card): void {
+    applyCard(play.world, play.avatarId, card);
+    stack.pop(); // DraftScene
+    play.advanceToNextWave();
+  }
+
+  btnRestart?.addEventListener("click", () => startNewRun());
+
+  startNewRun();
+
+  startLoop(
+    (dt) => stack.update(dt),
+    (alpha) => stack.render(alpha),
+  );
 }
 
 boot().catch((err) => {

--- a/shape-shift/src/render.ts
+++ b/shape-shift/src/render.ts
@@ -1,0 +1,110 @@
+import { Graphics } from "pixi.js";
+import type { World } from "./game/world";
+
+// One Graphics node redrawn each frame. Every entity is a tiny vector shape;
+// at <300 entities with simple paths this is well inside the single-draw-call
+// budget and avoids per-entity object churn.
+
+export function drawWorld(g: Graphics, world: World): void {
+  g.clear();
+
+  // Grid backdrop (very light) — draw once at the start.
+  g.setStrokeStyle({ width: 1, color: 0xf0f0f0 });
+  const STEP = 40;
+  // Kept as horizontal + vertical lines in play-field coords; the canvas
+  // already fills the whole 360×640.
+  for (let x = 0; x <= 360; x += STEP) { g.moveTo(x, 0); g.lineTo(x, 640); }
+  for (let y = 0; y <= 640; y += STEP) { g.moveTo(0, y); g.lineTo(360, y); }
+  g.stroke();
+
+  // Projectiles (magenta dots).
+  for (const [, c] of world.with("projectile", "pos", "radius")) {
+    const color = c.projectile!.crit ? 0xff3030 : 0xd81b60;
+    g.circle(c.pos!.x, c.pos!.y, c.radius!);
+    g.fill({ color });
+  }
+
+  // Enemies.
+  for (const [, c] of world.with("enemy", "pos", "radius")) {
+    const { x, y } = c.pos!;
+    const r = c.radius!;
+    const kind = c.enemy!.kind;
+    const flash = (c.flash ?? 0) > 0;
+    const fillColor = flash ? 0xffffff : enemyColor(kind);
+    const strokeColor = 0x111111;
+    drawEnemyShape(g, kind, x, y, r);
+    g.fill({ color: fillColor });
+    drawEnemyShape(g, kind, x, y, r);
+    g.stroke({ color: strokeColor, width: 2 });
+  }
+
+  // Avatar (triangle). Flash white briefly on hit; iframes produce a ring.
+  for (const [, c] of world.with("avatar", "pos", "radius")) {
+    const { x, y } = c.pos!;
+    const r = c.radius!;
+    const a = c.avatar!;
+    const bodyFill = (c.flash ?? 0) > 0 ? 0xffffff : 0x111111;
+    const h = r * Math.sqrt(3) / 2;
+    g.moveTo(x, y - h * 0.9);
+    g.lineTo(x + r * 0.9, y + h * 0.6);
+    g.lineTo(x - r * 0.9, y + h * 0.6);
+    g.closePath();
+    g.fill({ color: bodyFill });
+    g.stroke({ color: 0x111111, width: 2 });
+    if (a.iframes > 0) {
+      g.circle(x, y, r + 4);
+      g.stroke({ color: 0x00bcd4, width: 1.5 });
+    }
+  }
+}
+
+function enemyColor(kind: string): number {
+  switch (kind) {
+    case "circle":  return 0xfafafa;
+    case "square":  return 0xffe6a0;
+    case "star":    return 0xc9e7ff;
+    case "boss":    return 0xffd1e1;
+    default:        return 0xffffff;
+  }
+}
+
+function drawEnemyShape(g: Graphics, kind: string, x: number, y: number, r: number): void {
+  switch (kind) {
+    case "circle":
+      g.circle(x, y, r);
+      break;
+    case "square":
+      g.rect(x - r, y - r, r * 2, r * 2);
+      break;
+    case "star":
+      drawStar(g, x, y, r, 5);
+      break;
+    case "boss":
+      drawPolygon(g, x, y, r, 6);
+      break;
+    default:
+      g.circle(x, y, r);
+  }
+}
+
+function drawPolygon(g: Graphics, cx: number, cy: number, r: number, sides: number): void {
+  for (let i = 0; i < sides; i++) {
+    const a = (i / sides) * Math.PI * 2 - Math.PI / 2;
+    const x = cx + Math.cos(a) * r;
+    const y = cy + Math.sin(a) * r;
+    if (i === 0) g.moveTo(x, y); else g.lineTo(x, y);
+  }
+  g.closePath();
+}
+
+function drawStar(g: Graphics, cx: number, cy: number, r: number, points: number): void {
+  const inner = r * 0.45;
+  for (let i = 0; i < points * 2; i++) {
+    const rad = i % 2 === 0 ? r : inner;
+    const a = (i / (points * 2)) * Math.PI * 2 - Math.PI / 2;
+    const x = cx + Math.cos(a) * rad;
+    const y = cy + Math.sin(a) * rad;
+    if (i === 0) g.moveTo(x, y); else g.lineTo(x, y);
+  }
+  g.closePath();
+}

--- a/shape-shift/src/scenes/draft.ts
+++ b/shape-shift/src/scenes/draft.ts
@@ -1,0 +1,79 @@
+import { Container } from "pixi.js";
+import type { Card } from "../game/cards";
+import type { Scene } from "./scene";
+
+// Overlay-based scene — no Pixi drawing. Renders into `#overlay-inner` and
+// waits for a tap on one of the offered cards.
+
+export class DraftScene implements Scene {
+  readonly root: Container;
+  private readonly offer: readonly Card[];
+  private readonly onPick: (card: Card) => void;
+  private readonly clearedWaveLabel: string;
+
+  constructor(offer: readonly Card[], clearedWaveLabel: string, onPick: (card: Card) => void) {
+    this.root = new Container();
+    this.offer = offer;
+    this.onPick = onPick;
+    this.clearedWaveLabel = clearedWaveLabel;
+  }
+
+  enter(): void {
+    const overlay = document.getElementById("overlay");
+    const inner = document.getElementById("overlay-inner");
+    if (!overlay || !inner) return;
+    inner.innerHTML = "";
+
+    const title = document.createElement("div");
+    title.className = "overlay-title";
+    title.textContent = `wave ${this.clearedWaveLabel} cleared — pick a rune`;
+    inner.appendChild(title);
+
+    const list = document.createElement("div");
+    list.className = "card-list";
+    for (const card of this.offer) {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "card-btn";
+      btn.setAttribute("data-card-id", card.id);
+
+      const glyph = document.createElement("span");
+      glyph.className = "card-glyph";
+      glyph.textContent = card.glyph;
+      glyph.setAttribute("aria-hidden", "true");
+      btn.appendChild(glyph);
+
+      const body = document.createElement("span");
+      body.className = "card-body";
+      const name = document.createElement("span");
+      name.className = "card-name";
+      name.textContent = card.name;
+      const text = document.createElement("span");
+      text.className = "card-text";
+      text.textContent = card.text;
+      const rarity = document.createElement("span");
+      rarity.className = "card-rarity";
+      rarity.textContent = card.rarity;
+      body.appendChild(name);
+      body.appendChild(text);
+      body.appendChild(rarity);
+      btn.appendChild(body);
+
+      btn.addEventListener("click", () => this.onPick(card));
+      list.appendChild(btn);
+    }
+    inner.appendChild(list);
+    overlay.hidden = false;
+  }
+
+  exit(): void {
+    const overlay = document.getElementById("overlay");
+    const inner = document.getElementById("overlay-inner");
+    if (inner) inner.innerHTML = "";
+    if (overlay) overlay.hidden = true;
+  }
+
+  update(_dt: number): void {}
+
+  render(_alpha: number): void {}
+}

--- a/shape-shift/src/scenes/endgame.ts
+++ b/shape-shift/src/scenes/endgame.ts
@@ -1,0 +1,63 @@
+import { Container } from "pixi.js";
+import type { Scene } from "./scene";
+
+// Combined overlay scene for game-over / win. Content varies by flavour; both
+// end the run and offer a tap-to-restart button.
+
+export type EndgameKind = "dead" | "won";
+
+export class EndgameScene implements Scene {
+  readonly root: Container;
+  private readonly kind: EndgameKind;
+  private readonly wavesCleared: number;
+  private readonly totalWaves: number;
+  private readonly onRestart: () => void;
+
+  constructor(kind: EndgameKind, wavesCleared: number, totalWaves: number, onRestart: () => void) {
+    this.root = new Container();
+    this.kind = kind;
+    this.wavesCleared = wavesCleared;
+    this.totalWaves = totalWaves;
+    this.onRestart = onRestart;
+  }
+
+  enter(): void {
+    const overlay = document.getElementById("overlay");
+    const inner = document.getElementById("overlay-inner");
+    if (!overlay || !inner) return;
+    inner.innerHTML = "";
+
+    const title = document.createElement("div");
+    title.className = "overlay-title";
+    title.textContent = this.kind === "dead" ? "shattered" : "run complete";
+    inner.appendChild(title);
+
+    const sub = document.createElement("div");
+    sub.className = "overlay-sub";
+    sub.textContent =
+      this.kind === "dead"
+        ? `reached wave ${this.wavesCleared}/${this.totalWaves}`
+        : `cleared ${this.totalWaves}/${this.totalWaves} waves`;
+    inner.appendChild(sub);
+
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "big-btn";
+    btn.textContent = "new run";
+    btn.addEventListener("click", () => this.onRestart());
+    inner.appendChild(btn);
+
+    overlay.hidden = false;
+  }
+
+  exit(): void {
+    const overlay = document.getElementById("overlay");
+    const inner = document.getElementById("overlay-inner");
+    if (inner) inner.innerHTML = "";
+    if (overlay) overlay.hidden = true;
+  }
+
+  update(_dt: number): void {}
+
+  render(_alpha: number): void {}
+}

--- a/shape-shift/src/scenes/play.ts
+++ b/shape-shift/src/scenes/play.ts
@@ -1,0 +1,171 @@
+import { Container, Graphics } from "pixi.js";
+
+import { spawnAvatar } from "../game/entities";
+import type { Rng } from "../game/rng";
+import { updateEnemyAi } from "../game/systems/ai";
+import { removeDeadEnemies, updateCollisions } from "../game/systems/collision";
+import { decayHitFlash, updateAvatarMotion, updateProjectileMotion } from "../game/systems/motion";
+import { newWaveState, updateWave, type WaveState } from "../game/systems/wave";
+import { updateWeapon } from "../game/systems/weapon";
+import { TOTAL_WAVES, WAVES } from "../game/waves";
+import { type EntityId, World } from "../game/world";
+import { drawWorld } from "../render";
+import type { Scene } from "./scene";
+
+export interface PlayCallbacks {
+  onWaveCleared: (clearedIdx: number) => void; // 1-based
+  onPlayerDied: () => void;
+  onRunWon: () => void;
+  updateHud: (hp: number, maxHp: number, waveIdx: number, totalWaves: number) => void;
+}
+
+// Bridges play-field coords ↔ client coords. The canvas CSS size varies per
+// viewport; we map pointer events back to the fixed 360×640 play-field.
+export interface PointerMapper {
+  clientToPlay: (clientX: number, clientY: number) => { x: number; y: number };
+  target: HTMLElement; // where to attach pointer listeners
+}
+
+export class PlayScene implements Scene {
+  readonly root: Container;
+  readonly world: World;
+  avatarId: EntityId;
+
+  private readonly rng: Rng;
+  private readonly g: Graphics;
+  private readonly cb: PlayCallbacks;
+  private readonly mapper: PointerMapper;
+  private waveIdx: number; // 0-based
+  private wave: WaveState;
+  private tracking = false;
+  private boundOnDown: (ev: PointerEvent) => void;
+  private boundOnMove: (ev: PointerEvent) => void;
+  private boundOnUp: (ev: PointerEvent) => void;
+  private paused = false;
+  private ended = false;
+
+  constructor(rng: Rng, cb: PlayCallbacks, mapper: PointerMapper) {
+    this.root = new Container();
+    this.g = new Graphics();
+    this.root.addChild(this.g);
+    this.world = new World();
+    this.rng = rng;
+    this.cb = cb;
+    this.mapper = mapper;
+    this.avatarId = spawnAvatar(this.world);
+    this.waveIdx = 0;
+    this.wave = newWaveState(WAVES[this.waveIdx]!);
+
+    this.boundOnDown = (ev) => this.onPointerDown(ev);
+    this.boundOnMove = (ev) => this.onPointerMove(ev);
+    this.boundOnUp = (ev) => this.onPointerUp(ev);
+    this.updateHud();
+  }
+
+  enter(): void {
+    this.paused = false;
+    const t = this.mapper.target;
+    t.addEventListener("pointerdown", this.boundOnDown);
+    t.addEventListener("pointermove", this.boundOnMove);
+    t.addEventListener("pointerup", this.boundOnUp);
+    t.addEventListener("pointercancel", this.boundOnUp);
+  }
+
+  exit(): void {
+    this.paused = true;
+    this.tracking = false;
+    const t = this.mapper.target;
+    t.removeEventListener("pointerdown", this.boundOnDown);
+    t.removeEventListener("pointermove", this.boundOnMove);
+    t.removeEventListener("pointerup", this.boundOnUp);
+    t.removeEventListener("pointercancel", this.boundOnUp);
+  }
+
+  advanceToNextWave(): void {
+    if (this.waveIdx + 1 >= TOTAL_WAVES) return;
+    this.waveIdx += 1;
+    this.wave = newWaveState(WAVES[this.waveIdx]!);
+    this.ended = false;
+    this.updateHud();
+  }
+
+  currentWave1(): number {
+    return this.waveIdx + 1;
+  }
+
+  totalWaves(): number {
+    return TOTAL_WAVES;
+  }
+
+  update(dt: number): void {
+    if (this.paused || this.ended) return;
+
+    updateWave(this.wave, this.world, this.rng, dt);
+    updateAvatarMotion(this.world, dt);
+    updateEnemyAi(this.world, this.avatarId, dt);
+    updateProjectileMotion(this.world, dt);
+    updateWeapon(this.world, this.avatarId, this.rng, dt);
+
+    let died = false;
+    updateCollisions(this.world, this.avatarId, {
+      onPlayerDied: () => { died = true; },
+    });
+    removeDeadEnemies(this.world);
+    decayHitFlash(this.world, dt);
+
+    this.updateHud();
+
+    if (died) {
+      this.ended = true;
+      this.cb.onPlayerDied();
+      return;
+    }
+
+    if (this.wave.cleared) {
+      const cleared = this.waveIdx + 1; // 1-based for display
+      if (cleared >= TOTAL_WAVES) {
+        this.ended = true;
+        this.cb.onRunWon();
+      } else {
+        this.cb.onWaveCleared(cleared);
+      }
+    }
+  }
+
+  render(_alpha: number): void {
+    drawWorld(this.g, this.world);
+  }
+
+  private updateHud(): void {
+    const c = this.world.get(this.avatarId);
+    const hp = c?.avatar?.hp ?? 0;
+    const maxHp = c?.avatar?.maxHp ?? 0;
+    this.cb.updateHud(hp, maxHp, this.waveIdx + 1, TOTAL_WAVES);
+  }
+
+  private onPointerDown(ev: PointerEvent): void {
+    this.tracking = true;
+    (this.mapper.target as HTMLElement & { setPointerCapture?: (id: number) => void })
+      .setPointerCapture?.(ev.pointerId);
+    this.setAvatarTarget(ev.clientX, ev.clientY);
+  }
+
+  private onPointerMove(ev: PointerEvent): void {
+    if (!this.tracking) return;
+    this.setAvatarTarget(ev.clientX, ev.clientY);
+  }
+
+  private onPointerUp(ev: PointerEvent): void {
+    this.tracking = false;
+    (this.mapper.target as HTMLElement & { releasePointerCapture?: (id: number) => void })
+      .releasePointerCapture?.(ev.pointerId);
+  }
+
+  private setAvatarTarget(clientX: number, clientY: number): void {
+    const p = this.mapper.clientToPlay(clientX, clientY);
+    const a = this.world.get(this.avatarId)?.avatar;
+    if (!a) return;
+    a.targetX = p.x;
+    a.targetY = p.y;
+  }
+}

--- a/shape-shift/src/scenes/scene.ts
+++ b/shape-shift/src/scenes/scene.ts
@@ -1,0 +1,48 @@
+import type { Container } from "pixi.js";
+
+// Minimal scene stack. `enter/exit` toggle the scene's Pixi container visibility
+// and let the scene wire/unwire its DOM overlay. `update` runs only on the top
+// scene; `render` draws every active scene so overlays can sit on frozen play.
+
+export interface Scene {
+  readonly root: Container;
+  enter?(): void;
+  exit?(): void;
+  update(dt: number): void;
+  render(alpha: number): void;
+}
+
+export class SceneStack {
+  private readonly stack: Scene[] = [];
+
+  push(s: Scene): void {
+    this.stack[this.stack.length - 1]?.exit?.();
+    this.stack.push(s);
+    s.root.visible = true;
+    s.enter?.();
+  }
+
+  pop(): void {
+    const s = this.stack.pop();
+    s?.exit?.();
+    if (s) s.root.visible = false;
+    this.stack[this.stack.length - 1]?.enter?.();
+  }
+
+  replace(s: Scene): void {
+    this.pop();
+    this.push(s);
+  }
+
+  top(): Scene | undefined {
+    return this.stack[this.stack.length - 1];
+  }
+
+  update(dt: number): void {
+    this.top()?.update(dt);
+  }
+
+  render(alpha: number): void {
+    for (const s of this.stack) s.render(alpha);
+  }
+}

--- a/shape-shift/src/style.css
+++ b/shape-shift/src/style.css
@@ -2,7 +2,8 @@
   --bg: #ffffff;
   --fg: #111111;
   --accent: #d81b60;
-  --muted: #888888;
+  --muted: #8a8a99;
+  --chrome: #f4f4f6;
   color-scheme: light;
 }
 
@@ -29,12 +30,48 @@ body {
   inset: 0;
   display: flex;
   flex-direction: column;
-  align-items: stretch;
   background: var(--bg);
 }
 
-/* Portrait-locked play area: 9:16 ratio, centered, bounded by viewport.
-   Shorter side = width, taller side = height. Letterbox with white on wide screens. */
+#topbar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px calc(4px + env(safe-area-inset-top)) 12px;
+  font-size: 12px;
+  color: var(--muted);
+  background: var(--bg);
+  border-bottom: 1px solid var(--chrome);
+}
+
+.hud-chip {
+  display: inline-block;
+  padding: 4px 8px;
+  background: var(--chrome);
+  color: var(--fg);
+  border-radius: 6px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+#topbar .ctrl-btn {
+  margin-left: auto;
+  appearance: none;
+  border: 1px solid #ccc;
+  background: #fff;
+  color: var(--fg);
+  font: inherit;
+  padding: 4px 10px;
+  min-height: 32px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+#topbar .ctrl-btn:active {
+  background: var(--chrome);
+}
+
 #game {
   flex: 1 1 auto;
   position: relative;
@@ -43,39 +80,132 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
+  overflow: hidden;
 }
 
 #game canvas {
   display: block;
   background: var(--bg);
-  /* JS sizes the canvas; CSS just prevents inline-defaults messing with it. */
-  image-rendering: pixelated;
+  image-rendering: auto;
 }
 
-#hud {
-  flex: 0 0 auto;
+#overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.82);
+  backdrop-filter: blur(2px);
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  padding: 8px 12px calc(8px + env(safe-area-inset-bottom)) 12px;
-  font-size: 12px;
-  color: var(--muted);
-  border-top: 1px solid #eee;
-  background: var(--bg);
+  justify-content: center;
+  padding: 16px;
+  z-index: 5;
 }
 
-#hud button {
+#overlay[hidden] { display: none; }
+
+#overlay-inner {
+  width: 100%;
+  max-width: 340px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
+}
+
+.overlay-title {
+  text-align: center;
+  font-size: 16px;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+
+.overlay-sub {
+  text-align: center;
+  font-size: 14px;
+  color: var(--fg);
+}
+
+.card-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.card-btn {
   appearance: none;
-  border: 1px solid #ccc;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  min-height: 60px;
+  border: 1px solid #ddd;
+  border-radius: 10px;
   background: #fff;
   color: var(--fg);
   font: inherit;
-  padding: 6px 12px;
-  min-height: 36px;
-  border-radius: 6px;
+  text-align: left;
   cursor: pointer;
 }
 
-#hud button:active {
-  background: #f0f0f0;
+.card-btn:active {
+  background: var(--chrome);
+}
+
+.card-glyph {
+  font-size: 28px;
+  line-height: 1;
+  width: 36px;
+  text-align: center;
+}
+
+.card-body {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.card-name {
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.card-text {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.card-rarity {
+  font-size: 10px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.big-btn {
+  appearance: none;
+  padding: 14px 16px;
+  min-height: 52px;
+  border: 1px solid var(--fg);
+  border-radius: 10px;
+  background: var(--fg);
+  color: #fff;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.big-btn:active {
+  background: #000;
+}
+
+#footer-hint {
+  flex: 0 0 auto;
+  padding: 6px 12px calc(6px + env(safe-area-inset-bottom)) 12px;
+  font-size: 11px;
+  color: var(--muted);
+  text-align: center;
+  border-top: 1px solid var(--chrome);
+  background: var(--bg);
 }

--- a/shape-shift/tests/cards.test.ts
+++ b/shape-shift/tests/cards.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { applyCard, drawOffer, POOL, type Card } from "../src/game/cards";
+import { spawnAvatar } from "../src/game/entities";
+import { createRng } from "../src/game/rng";
+import { World } from "../src/game/world";
+
+describe("drawOffer", () => {
+  it("returns the requested count without duplicates", () => {
+    const offer = drawOffer(createRng(1), 3);
+    expect(offer).toHaveLength(3);
+    const ids = offer.map((c) => c.id);
+    expect(new Set(ids).size).toBe(3);
+  });
+
+  it("is deterministic for the same seed", () => {
+    const a = drawOffer(createRng(42), 3).map((c) => c.id);
+    const b = drawOffer(createRng(42), 3).map((c) => c.id);
+    expect(a).toEqual(b);
+  });
+
+  it("tolerates a count larger than the pool", () => {
+    const offer = drawOffer(createRng(7), POOL.length + 5);
+    expect(offer).toHaveLength(POOL.length);
+  });
+});
+
+describe("applyCard", () => {
+  const cardById = (id: string): Card => {
+    const found = POOL.find((c) => c.id === id);
+    if (!found) throw new Error(`no card '${id}'`);
+    return found;
+  };
+
+  it("sharp adds 1 damage to the weapon", () => {
+    const world = new World();
+    const id = spawnAvatar(world);
+    const before = world.get(id)!.weapon!.damage;
+    applyCard(world, id, cardById("sharp"));
+    expect(world.get(id)!.weapon!.damage).toBe(before + 1);
+  });
+
+  it("rapid multiplies fire period by 0.8 and clamps to >= 0.05", () => {
+    const world = new World();
+    const id = spawnAvatar(world);
+    const before = world.get(id)!.weapon!.period;
+    applyCard(world, id, cardById("rapid"));
+    expect(world.get(id)!.weapon!.period).toBeCloseTo(before * 0.8, 6);
+    for (let i = 0; i < 100; i++) applyCard(world, id, cardById("rapid"));
+    expect(world.get(id)!.weapon!.period).toBeGreaterThanOrEqual(0.05);
+  });
+
+  it("fork increases projectiles by 1", () => {
+    const world = new World();
+    const id = spawnAvatar(world);
+    const before = world.get(id)!.weapon!.projectiles;
+    applyCard(world, id, cardById("fork"));
+    expect(world.get(id)!.weapon!.projectiles).toBe(before + 1);
+  });
+
+  it("pierce increases pierce count by 1", () => {
+    const world = new World();
+    const id = spawnAvatar(world);
+    const before = world.get(id)!.weapon!.pierce;
+    applyCard(world, id, cardById("pierce"));
+    expect(world.get(id)!.weapon!.pierce).toBe(before + 1);
+  });
+
+  it("crit stacks up to 1.0", () => {
+    const world = new World();
+    const id = spawnAvatar(world);
+    for (let i = 0; i < 10; i++) applyCard(world, id, cardById("crit"));
+    expect(world.get(id)!.weapon!.crit).toBe(1);
+  });
+
+  it("plating raises both current and max hp", () => {
+    const world = new World();
+    const id = spawnAvatar(world);
+    const a = world.get(id)!.avatar!;
+    a.hp = 1; // mid-combat simulation
+    const beforeMax = a.maxHp;
+    applyCard(world, id, cardById("plating"));
+    expect(a.maxHp).toBe(beforeMax + 1);
+    expect(a.hp).toBe(2);
+  });
+
+  it("dash multiplies avatar speedMul by 1.2", () => {
+    const world = new World();
+    const id = spawnAvatar(world);
+    const before = world.get(id)!.avatar!.speedMul;
+    applyCard(world, id, cardById("dash"));
+    expect(world.get(id)!.avatar!.speedMul).toBeCloseTo(before * 1.2, 6);
+  });
+});

--- a/shape-shift/tests/wave.test.ts
+++ b/shape-shift/tests/wave.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { createRng } from "../src/game/rng";
+import { newWaveState, updateWave } from "../src/game/systems/wave";
+import { WAVES, type SpawnGroup, type WaveSpec } from "../src/game/waves";
+import { World } from "../src/game/world";
+
+function countEnemies(world: World): number {
+  let n = 0;
+  for (const [, c] of world.with("enemy")) {
+    if ((c.hp?.value ?? 0) > 0) n++;
+  }
+  return n;
+}
+
+function tick(state: { elapsed: number; nextGroupIdx: number; cleared: boolean; spec: WaveSpec }, world: World, rng: () => number, steps: number, dt = 1 / 60): void {
+  for (let i = 0; i < steps; i++) updateWave(state, world, rng, dt);
+}
+
+describe("WAVES spec sanity", () => {
+  it("has 8 waves with monotonic indices", () => {
+    expect(WAVES).toHaveLength(8);
+    WAVES.forEach((w, i) => expect(w.index).toBe(i + 1));
+  });
+
+  it("every wave has at least one spawn group", () => {
+    for (const w of WAVES) expect(w.groups.length).toBeGreaterThan(0);
+  });
+
+  it("spawn groups fire in non-decreasing time order", () => {
+    for (const w of WAVES) {
+      for (let i = 1; i < w.groups.length; i++) {
+        expect(w.groups[i]!.t).toBeGreaterThanOrEqual(w.groups[i - 1]!.t);
+      }
+    }
+  });
+
+  it("only the final wave spawns a boss", () => {
+    WAVES.forEach((w, i) => {
+      const hasBoss = w.groups.some((g: SpawnGroup) => g.kind === "boss");
+      if (i === WAVES.length - 1) expect(hasBoss).toBe(true);
+      else expect(hasBoss).toBe(false);
+    });
+  });
+});
+
+describe("updateWave", () => {
+  it("spawns groups at their scheduled times", () => {
+    const world = new World();
+    const rng = createRng(1);
+    const spec = WAVES[0]!;
+    const state = newWaveState(spec);
+    // first group fires at t=0.5 with 3 circles.
+    tick(state, world, rng, 40); // ~0.67s
+    expect(countEnemies(world)).toBe(3);
+  });
+
+  it("does not mark cleared until every group has fired", () => {
+    const world = new World();
+    const rng = createRng(2);
+    const spec = WAVES[0]!;
+    const state = newWaveState(spec);
+    tick(state, world, rng, 60 * 3); // 3 seconds — only first group has fired
+    expect(state.cleared).toBe(false);
+  });
+
+  it("clears once all groups fired and enemies wiped", () => {
+    const world = new World();
+    const rng = createRng(3);
+    const spec = WAVES[0]!;
+    const state = newWaveState(spec);
+    // Advance past the last group time and remove enemies before the next tick.
+    const maxT = spec.groups[spec.groups.length - 1]!.t;
+    tick(state, world, rng, Math.ceil((maxT + 0.2) * 60));
+    // All enemies are defeated by the bored designer.
+    for (const [, c] of world.with("enemy", "hp")) c.hp!.value = 0;
+    updateWave(state, world, rng, 1 / 60);
+    expect(state.cleared).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the playable vertical slice on top of the merged scaffold. Without this, the deployed GitHub Pages build is still the scaffold (triangle on a white grid, no HUD, no enemies, no cards) — which matches the screen you just saw.

### What ships

- **Combat loop** — auto-fire weapon seeks the closest enemy; projectiles with pierce/crit/fan spread; circle-circle collisions with hit-flash and i-frames
- **Wave system** — 8 linear waves (`src/game/waves.ts`), groups scheduled on a per-wave timeline; w8 is a Mirror-Boss placeholder (single boss hex)
- **Draft scene** — between waves, pick 1 of 3 cards from a 10-card pool (sharp / rapid / velocity / fork / pierce / crit / plating / dash / overclock / heavy); DOM overlay, tap-to-pick
- **Endgame scene** — death shows `reached wave N/8`; win shows `cleared 8/8 waves`; both offer a `new run` button
- **Scene stack** — `Play` / `Draft` / `Endgame` via a minimal `SceneStack` (top-only update, bottom-up render) so the frozen play-field stays visible behind overlays
- **HUD** — topbar chips for HP / wave / seed, updated every tick via the `updateHud` callback

### Tests & build

- 23 vitest tests green (rng determinism, card drafting, wave sanity, `applyCard` effects)
- `tsc --noEmit` clean under strict mode
- `vite build` → 246 KB / 77 KB gzip

## Test plan

- [ ] CI deploy to GH Pages succeeds
- [ ] Landing page at `/2D-game-playground/` links to shape-shift
- [ ] `/2D-game-playground/shape-shift/` shows HUD chips (HP/W/seed)
- [ ] Enemies start appearing ~0.5s into wave 1
- [ ] Clearing wave 1 pops up the 3-card draft overlay
- [ ] Picking a card advances to wave 2 and applies its effect
- [ ] Dying shows `shattered / reached wave N/8` with `new run` button
- [ ] `new run` restarts cleanly without stale listeners

https://claude.ai/code/session_01WiAm56rKsTcc9SyXFLmA18