### PR TITLE
Fix mobile draft fat-finger + double-tap zoom; add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# Repo conventions
+
+## Workflow
+- When a task's changes are finished, pushed, and green, **always open a PR** (or update the existing one with a clear summary). Don't wait for the user to ask.
+- All work on feature branches (e.g. `claude/<task>-xxxxx`), never commit directly to `main`.
+
+## Subprojects
+- `simple-roguelike/` — existing roguelike; do not modify unless asked.
+- `shape-shift/` — reverse bullet-hell + card drafter; concept in `shape-shift/docs/concept.md`.
+- CI (`.github/workflows/deploy.yml`) builds both subprojects and publishes to GitHub Pages.

--- a/shape-shift/src/scenes/draft.ts
+++ b/shape-shift/src/scenes/draft.ts
@@ -10,6 +10,7 @@ export class DraftScene implements Scene {
   private readonly offer: readonly Card[];
   private readonly onPick: (card: Card) => void;
   private readonly clearedWaveLabel: string;
+  private selected: Card | null = null;
 
   constructor(offer: readonly Card[], clearedWaveLabel: string, onPick: (card: Card) => void) {
     this.root = new Container();
@@ -23,6 +24,7 @@ export class DraftScene implements Scene {
     const inner = document.getElementById("overlay-inner");
     if (!overlay || !inner) return;
     inner.innerHTML = "";
+    this.selected = null;
 
     const title = document.createElement("div");
     title.className = "overlay-title";
@@ -31,6 +33,7 @@ export class DraftScene implements Scene {
 
     const list = document.createElement("div");
     list.className = "card-list";
+    const btnByCard = new Map<string, HTMLButtonElement>();
     for (const card of this.offer) {
       const btn = document.createElement("button");
       btn.type = "button";
@@ -59,10 +62,30 @@ export class DraftScene implements Scene {
       body.appendChild(rarity);
       btn.appendChild(body);
 
-      btn.addEventListener("click", () => this.onPick(card));
+      btn.addEventListener("click", () => {
+        this.selected = card;
+        for (const [id, b] of btnByCard) b.classList.toggle("selected", id === card.id);
+        confirmBtn.disabled = false;
+        confirmBtn.textContent = `confirm: ${card.name}`;
+      });
+      btnByCard.set(card.id, btn);
       list.appendChild(btn);
     }
     inner.appendChild(list);
+
+    // Two-step commit: user selects a card, then confirms. Prevents an
+    // accidental tap (carried over from gameplay drag) from locking in a pick
+    // before the user has read the options.
+    const confirmBtn = document.createElement("button");
+    confirmBtn.type = "button";
+    confirmBtn.className = "big-btn";
+    confirmBtn.disabled = true;
+    confirmBtn.textContent = "pick a card first";
+    confirmBtn.addEventListener("click", () => {
+      if (this.selected) this.onPick(this.selected);
+    });
+    inner.appendChild(confirmBtn);
+
     overlay.hidden = false;
   }
 

--- a/shape-shift/src/style.css
+++ b/shape-shift/src/style.css
@@ -66,6 +66,7 @@ body {
   min-height: 32px;
   border-radius: 6px;
   cursor: pointer;
+  touch-action: manipulation;
 }
 
 #topbar .ctrl-btn:active {
@@ -81,12 +82,14 @@ body {
   align-items: center;
   justify-content: center;
   overflow: hidden;
+  touch-action: none;
 }
 
 #game canvas {
   display: block;
   background: var(--bg);
   image-rendering: auto;
+  touch-action: none;
 }
 
 #overlay {
@@ -146,9 +149,17 @@ body {
   font: inherit;
   text-align: left;
   cursor: pointer;
+  touch-action: manipulation;
 }
 
 .card-btn:active {
+  background: var(--chrome);
+}
+
+.card-btn.selected {
+  border-color: var(--fg);
+  border-width: 2px;
+  padding: 11px 13px;
   background: var(--chrome);
 }
 
@@ -194,10 +205,18 @@ body {
   font: inherit;
   font-weight: 700;
   cursor: pointer;
+  touch-action: manipulation;
 }
 
 .big-btn:active {
   background: #000;
+}
+
+.big-btn:disabled {
+  background: #ccc;
+  border-color: #ccc;
+  color: #fff;
+  cursor: not-allowed;
 }
 
 #footer-hint {


### PR DESCRIPTION
## Summary

Follow-ups on mobile playtest feedback after PR #8 shipped:

- **Draft fat-finger** — tapping a card used to commit the pick instantly, which fires accidentally when the wave-clear modal lands under a finger still mid-drag. Split into a two-step flow: tap selects (highlighted border + tint), then a disabled-until-selected `confirm: <card>` big button commits.
- **iOS double-tap zoom** — `body { touch-action: none }` doesn't inherit, so buttons and the canvas were still accepting the zoom gesture. Set `touch-action: manipulation` on `.card-btn` / `.big-btn` / `.ctrl-btn`, and `touch-action: none` on `#game` and its canvas.
- **Repo convention** — add `CLAUDE.md` recording the "open a PR at end of every task" workflow so future sessions don't need the reminder.

## Test plan

- [ ] Redeploy → on mobile, rapid double-tap inside the play-field no longer zooms the page
- [ ] Clearing a wave shows three cards with a disabled `pick a card first` button
- [ ] Tapping a card highlights it and the confirm button enables as `confirm: <card-name>`
- [ ] Tapping a second card swaps the highlight (only one selected at a time)
- [ ] Confirm applies the card and advances to the next wave
- [ ] 23 vitest tests + `tsc --noEmit` + `vite build` all green (verified locally)

https://claude.ai/code/session_01WiAm56rKsTcc9SyXFLmA18