### PR TITLE
Require subscribing to PR activity after opening a PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,7 @@
 
 ## Workflow
 - When a task's changes are finished, pushed, and green, **always open a PR** (or update the existing one with a clear summary). Don't wait for the user to ask.
+- After opening or updating a PR, **always subscribe to its activity** via `mcp__github__subscribe_pr_activity` so CI failures and review comments surface automatically.
 - All work on feature branches (e.g. `claude/<task>-xxxxx`), never commit directly to `main`.
 
 ## Subprojects


### PR DESCRIPTION
## Summary
- CLAUDE.md 加一條 workflow 規則：每次開 PR 或更新 PR 後，必須呼叫 `mcp__github__subscribe_pr_activity` 訂閱該 PR，讓 CI 失敗與 review 留言自動進到對話串，不用手動問

## Test plan
- [x] `git diff` 只涉及 `CLAUDE.md`
- [ ] 之後開 PR 時會自動遵守（下一個 PR 驗收）