### PR TITLE
Add 4 Synergy cards (Combustion / Desperate / Kinetic / Stillness)

### DIFF
--- a/axiom/src/game/cards.ts
+++ b/axiom/src/game/cards.ts
@@ -1,5 +1,5 @@
 import { type Rng, shuffle } from "./rng";
-import type { World, EntityId } from "./world";
+import type { EntityId, SynergyId, World } from "./world";
 
 export type Rarity = "common" | "uncommon" | "rare";
 
@@ -15,7 +15,8 @@ export type CardEffect =
   | { kind: "ricochetAdd"; value: number }
   | { kind: "chainAdd"; value: number }
   | { kind: "burnAdd"; dps: number; duration: number }
-  | { kind: "slowAdd"; pct: number; duration: number };
+  | { kind: "slowAdd"; pct: number; duration: number }
+  | { kind: "synergy"; id: SynergyId };
 
 export interface Card {
   id: string;
@@ -41,6 +42,10 @@ export const POOL: readonly Card[] = [
   { id: "ignite",     name: "Ignite",        glyph: "※", rarity: "rare",     text: "Burn 2 dps for 3s",      effect: { kind: "burnAdd", dps: 2, duration: 3 } },
   { id: "freeze",     name: "Freeze",        glyph: "❄", rarity: "uncommon", text: "Slow 35% for 2s",        effect: { kind: "slowAdd", pct: 0.35, duration: 2 } },
   { id: "arc",        name: "Arc",           glyph: "⌇", rarity: "rare",     text: "+1 chain",               effect: { kind: "chainAdd", value: 1 } },
+  { id: "combustion", name: "Combustion",    glyph: "❂", rarity: "rare",     text: "Every 10 kills: AoE explosion", effect: { kind: "synergy", id: "combustion" } },
+  { id: "desperate",  name: "Desperate",     glyph: "✖", rarity: "rare",     text: "While HP ≤ 2: ×2 damage",       effect: { kind: "synergy", id: "desperate" } },
+  { id: "kinetic",    name: "Kinetic",       glyph: "↯", rarity: "uncommon", text: "While moving: +25% crit",       effect: { kind: "synergy", id: "kinetic" } },
+  { id: "stillness",  name: "Stillness",     glyph: "◦", rarity: "uncommon", text: "While still: -25% fire interval", effect: { kind: "synergy", id: "stillness" } },
 ];
 
 export function drawOffer(rng: Rng, count: number, pool: readonly Card[] = POOL): Card[] {
@@ -73,6 +78,13 @@ export function applyCard(world: World, avatarId: EntityId, card: Card): void {
     case "slowAdd":
       c.weapon.slowPct = Math.min(0.9, c.weapon.slowPct + e.pct);
       c.weapon.slowDuration = Math.max(c.weapon.slowDuration, e.duration);
+      break;
+    case "synergy":
+      if (!c.avatar.synergies) c.avatar.synergies = [];
+      // Combustion starts at 0 kills; others carry no per-instance state.
+      c.avatar.synergies.push(
+        e.id === "combustion" ? { id: e.id, killCounter: 0 } : { id: e.id },
+      );
       break;
   }
 }

--- a/axiom/src/game/mirrorBoss.ts
+++ b/axiom/src/game/mirrorBoss.ts
@@ -91,6 +91,15 @@ export function mirrorBossSpec(picks: readonly Card[]): MirrorBossSpec {
         // Slow on the player is harsh; mirror as boss moving faster.
         maxSpeed *= 1 + e.pct * 0.5;
         break;
+      case "synergy":
+        // Conditional player buffs mirror as flat stat increases on the boss.
+        switch (e.id) {
+          case "combustion": w.damage += 2; break;
+          case "desperate":  hp += 15; break;
+          case "kinetic":    maxSpeed *= 1.15; break;
+          case "stillness":  w.period = Math.max(0.2, w.period * 0.85); break;
+        }
+        break;
     }
   }
 

--- a/axiom/src/game/synergies.ts
+++ b/axiom/src/game/synergies.ts
@@ -1,0 +1,93 @@
+import { HIT_FLASH_TIME } from "./config";
+import type { GameEvents } from "./events";
+import type { Avatar, EntityId, SynergyRuntime, World } from "./world";
+
+export type { SynergyId, SynergyRuntime } from "./world";
+
+export const SYNERGY_CONFIG = {
+  combustion: { interval: 10, radius: 60, damage: 2 },
+  desperate:  { hpThreshold: 2, damageMul: 2 },
+  kinetic:    { critAdd: 0.25, moveEps: 1 },
+  stillness:  { periodMul: 0.75, moveEps: 1 },
+} as const;
+
+export interface SynergyBonuses {
+  damageMul: number;
+  periodMul: number;
+  critAdd: number;
+}
+
+const NEUTRAL: SynergyBonuses = { damageMul: 1, periodMul: 1, critAdd: 0 };
+
+function isMoving(avatar: Avatar, velMag: number): boolean {
+  return velMag > SYNERGY_CONFIG.kinetic.moveEps && avatar.speedMul > 0;
+}
+
+export function computeSynergyBonuses(
+  synergies: readonly SynergyRuntime[] | undefined,
+  avatar: Avatar,
+  velMag: number,
+): SynergyBonuses {
+  if (!synergies || synergies.length === 0) return { ...NEUTRAL };
+  let damageMul = 1;
+  let periodMul = 1;
+  let critAdd = 0;
+  const moving = isMoving(avatar, velMag);
+  for (const s of synergies) {
+    switch (s.id) {
+      case "desperate":
+        if (avatar.hp <= SYNERGY_CONFIG.desperate.hpThreshold) {
+          damageMul *= SYNERGY_CONFIG.desperate.damageMul;
+        }
+        break;
+      case "kinetic":
+        if (moving) critAdd += SYNERGY_CONFIG.kinetic.critAdd;
+        break;
+      case "stillness":
+        if (!moving) periodMul *= SYNERGY_CONFIG.stillness.periodMul;
+        break;
+      case "combustion":
+        break;
+    }
+  }
+  return { damageMul, periodMul, critAdd };
+}
+
+/**
+ * Damage every enemy whose body overlaps a circle at `(x,y)` with radius `r`.
+ * Mirrors collision.ts shield handling and emits onEnemyKilled for kills.
+ * Returns the entity ids of killed enemies so the caller can continue counters.
+ */
+export function explodeAt(
+  world: World,
+  x: number,
+  y: number,
+  radius: number,
+  damage: number,
+  events?: GameEvents,
+): EntityId[] {
+  const killed: EntityId[] = [];
+  for (const [id, c] of world.with("enemy", "pos", "hp", "radius")) {
+    const hp = c.hp!;
+    if (hp.value <= 0) continue;
+    const er = c.radius!;
+    const dx = c.pos!.x - x;
+    const dy = c.pos!.y - y;
+    const rr = radius + er;
+    if (dx * dx + dy * dy > rr * rr) continue;
+
+    if (c.enemy!.shield !== undefined && c.enemy!.shield > 0) {
+      c.enemy!.shield -= 1;
+      c.flash = HIT_FLASH_TIME;
+      continue;
+    }
+
+    hp.value -= damage;
+    c.flash = HIT_FLASH_TIME;
+    if (hp.value <= 0) {
+      killed.push(id);
+      events?.onEnemyKilled?.(id);
+    }
+  }
+  return killed;
+}

--- a/axiom/src/game/systems/weapon.ts
+++ b/axiom/src/game/systems/weapon.ts
@@ -1,5 +1,6 @@
 import { spawnProjectile } from "../entities";
 import type { Rng } from "../rng";
+import { computeSynergyBonuses } from "../synergies";
 import type { EntityId, World } from "../world";
 
 const FAN_SPREAD = 0.25;
@@ -38,6 +39,18 @@ export function updateWeapon(
     if (w.cooldown < -0.5) w.cooldown = 0;
     return;
   }
+
+  // Synergy bonuses (Desperate/Kinetic/Stillness) apply per-shot, never mutate
+  // the base WeaponState, so conditions that later stop holding revert cleanly.
+  const velMag = c.vel ? Math.hypot(c.vel.x, c.vel.y) : 0;
+  const bonus = c.avatar
+    ? computeSynergyBonuses(c.avatar.synergies, c.avatar, velMag)
+    : { damageMul: 1, periodMul: 1, critAdd: 0 };
+  const effPeriod = Math.max(0.05, w.period * bonus.periodMul);
+  const effDamage = w.damage * bonus.damageMul;
+  const effCrit = Math.min(1, w.crit + bonus.critAdd);
+  const effWeapon = { ...w, damage: effDamage, period: effPeriod, crit: effCrit };
+
   const target = world.get(targetId)!;
   const dx = target.pos!.x - c.pos.x;
   const dy = target.pos!.y - c.pos.y;
@@ -48,8 +61,8 @@ export function updateWeapon(
     const a = startAngle + FAN_SPREAD * i;
     const vx = Math.cos(a) * w.projectileSpeed;
     const vy = Math.sin(a) * w.projectileSpeed;
-    const crit = rng() < w.crit;
-    spawnProjectile(world, c.pos.x, c.pos.y, vx, vy, w, crit);
+    const crit = rng() < effCrit;
+    spawnProjectile(world, c.pos.x, c.pos.y, vx, vy, effWeapon, crit);
   }
-  w.cooldown = w.period;
+  w.cooldown = effPeriod;
 }

--- a/axiom/src/game/world.ts
+++ b/axiom/src/game/world.ts
@@ -62,6 +62,14 @@ export interface Enemy {
   slow?: { pct: number; remaining: number };
 }
 
+export type SynergyId = "combustion" | "desperate" | "kinetic" | "stillness";
+
+export interface SynergyRuntime {
+  id: SynergyId;
+  /** Combustion only: rolling kill count since last detonation. */
+  killCounter?: number;
+}
+
 export interface Avatar {
   hp: number;
   maxHp: number;
@@ -69,6 +77,8 @@ export interface Avatar {
   iframes: number;    // seconds of invulnerability remaining
   targetX: number;
   targetY: number;
+  /** Active synergy cards the player has drafted. Evaluated at fire time. */
+  synergies?: SynergyRuntime[];
 }
 
 export interface Components {

--- a/axiom/src/scenes/play.ts
+++ b/axiom/src/scenes/play.ts
@@ -26,6 +26,7 @@ import {
 } from "../game/skills";
 import { survivalWaveSpec, isMirrorBossWave, survivalHpScale, survivalSpeedScale } from "../game/survivalWaves";
 import type { StageTheme } from "../game/stageThemes";
+import { SYNERGY_CONFIG, explodeAt } from "../game/synergies";
 
 export type GameMode = "normal" | "survival";
 
@@ -246,10 +247,11 @@ export class PlayScene implements Scene {
     }
 
     let died = false;
-    const events = {
+    const events: import("../game/events").GameEvents = {
       onEnemyKilled: (eid: EntityId) => {
         playSfx("hit");
         this.onEnemyKilled(eid);
+        this.tickCombustion(events);
       },
       onPlayerDied: () => { died = true; },
     };
@@ -301,6 +303,24 @@ export class PlayScene implements Scene {
       const drop = rollBossLoot(this.rng);
       this.loot.push(drop);
       if (drop.kind === "points") this.runPoints += drop.value;
+    }
+  }
+
+  private tickCombustion(events: import("../game/events").GameEvents): void {
+    const a = this.world.get(this.avatarId);
+    const pos = a?.pos;
+    const synergies = a?.avatar?.synergies;
+    if (!pos || !synergies) return;
+    const cfg = SYNERGY_CONFIG.combustion;
+    for (const s of synergies) {
+      if (s.id !== "combustion") continue;
+      s.killCounter = (s.killCounter ?? 0) + 1;
+      if (s.killCounter >= cfg.interval) {
+        // Reset before firing so chain-kills start a fresh cycle and we can't
+        // re-trigger this same blast recursively.
+        s.killCounter = 0;
+        explodeAt(this.world, pos.x, pos.y, cfg.radius, cfg.damage, events);
+      }
     }
   }
 

--- a/axiom/tests/cards.test.ts
+++ b/axiom/tests/cards.test.ts
@@ -125,4 +125,24 @@ describe("applyCard", () => {
     expect(w.slowPct).toBe(0.9);
     expect(w.slowDuration).toBe(2);
   });
+
+  it("synergy cards register on avatar without touching weapon stats", () => {
+    const world = new World();
+    const id = spawnAvatar(world);
+    const weaponBefore = { ...world.get(id)!.weapon! };
+    const maxHpBefore = world.get(id)!.avatar!.maxHp;
+    for (const cid of ["combustion", "desperate", "kinetic", "stillness"]) {
+      applyCard(world, id, cardById(cid));
+    }
+    const avatar = world.get(id)!.avatar!;
+    expect(avatar.synergies?.map((s) => s.id)).toEqual([
+      "combustion",
+      "desperate",
+      "kinetic",
+      "stillness",
+    ]);
+    expect(avatar.synergies?.[0]?.killCounter).toBe(0);
+    expect(world.get(id)!.weapon).toEqual(weaponBefore);
+    expect(avatar.maxHp).toBe(maxHpBefore);
+  });
 });

--- a/axiom/tests/synergies.test.ts
+++ b/axiom/tests/synergies.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { spawnAvatar, spawnEnemy } from "../src/game/entities";
+import { createRng } from "../src/game/rng";
+import {
+  SYNERGY_CONFIG,
+  computeSynergyBonuses,
+  explodeAt,
+} from "../src/game/synergies";
+import { World, type Avatar, type SynergyRuntime } from "../src/game/world";
+
+const makeAvatar = (hp = 4): Avatar => ({
+  hp,
+  maxHp: 4,
+  speedMul: 1,
+  iframes: 0,
+  targetX: 0,
+  targetY: 0,
+});
+
+describe("computeSynergyBonuses", () => {
+  it("returns neutral bonuses when no synergies", () => {
+    const b = computeSynergyBonuses(undefined, makeAvatar(), 0);
+    expect(b).toEqual({ damageMul: 1, periodMul: 1, critAdd: 0 });
+  });
+
+  it("desperate doubles damage only when hp <= threshold", () => {
+    const s: SynergyRuntime[] = [{ id: "desperate" }];
+    const t = SYNERGY_CONFIG.desperate.hpThreshold;
+    expect(computeSynergyBonuses(s, makeAvatar(t), 0).damageMul).toBe(2);
+    expect(computeSynergyBonuses(s, makeAvatar(t - 1), 0).damageMul).toBe(2);
+    expect(computeSynergyBonuses(s, makeAvatar(t + 1), 0).damageMul).toBe(1);
+  });
+
+  it("kinetic adds crit only while moving", () => {
+    const s: SynergyRuntime[] = [{ id: "kinetic" }];
+    expect(computeSynergyBonuses(s, makeAvatar(), 10).critAdd).toBe(
+      SYNERGY_CONFIG.kinetic.critAdd,
+    );
+    expect(computeSynergyBonuses(s, makeAvatar(), 0).critAdd).toBe(0);
+  });
+
+  it("stillness cuts period only while stationary", () => {
+    const s: SynergyRuntime[] = [{ id: "stillness" }];
+    expect(computeSynergyBonuses(s, makeAvatar(), 0).periodMul).toBe(
+      SYNERGY_CONFIG.stillness.periodMul,
+    );
+    expect(computeSynergyBonuses(s, makeAvatar(), 10).periodMul).toBe(1);
+  });
+
+  it("kinetic + stillness are mutually exclusive by movement", () => {
+    const s: SynergyRuntime[] = [{ id: "kinetic" }, { id: "stillness" }];
+    const moving = computeSynergyBonuses(s, makeAvatar(), 10);
+    expect(moving.critAdd).toBeGreaterThan(0);
+    expect(moving.periodMul).toBe(1);
+    const still = computeSynergyBonuses(s, makeAvatar(), 0);
+    expect(still.critAdd).toBe(0);
+    expect(still.periodMul).toBeLessThan(1);
+  });
+
+  it("combustion contributes nothing to multipliers", () => {
+    const s: SynergyRuntime[] = [{ id: "combustion", killCounter: 5 }];
+    expect(computeSynergyBonuses(s, makeAvatar(), 10)).toEqual({
+      damageMul: 1,
+      periodMul: 1,
+      critAdd: 0,
+    });
+  });
+});
+
+describe("explodeAt", () => {
+  it("damages enemies inside the radius and skips those outside", () => {
+    const world = new World();
+    const rng = createRng(1);
+    // Spawn three circles; we'll teleport them manually into known positions.
+    const a = spawnEnemy(world, "circle", rng);
+    const b = spawnEnemy(world, "circle", rng);
+    const c = spawnEnemy(world, "circle", rng);
+    world.get(a)!.pos = { x: 100, y: 100 };
+    world.get(b)!.pos = { x: 140, y: 100 }; // 40 away, inside radius 60
+    world.get(c)!.pos = { x: 300, y: 300 }; // far outside
+
+    const hpBefore = {
+      a: world.get(a)!.hp!.value,
+      b: world.get(b)!.hp!.value,
+      c: world.get(c)!.hp!.value,
+    };
+    explodeAt(world, 100, 100, 60, 2);
+    expect(world.get(a)!.hp!.value).toBe(hpBefore.a - 2);
+    expect(world.get(b)!.hp!.value).toBe(hpBefore.b - 2);
+    expect(world.get(c)!.hp!.value).toBe(hpBefore.c);
+  });
+
+  it("absorbs the first hit on a shielded target instead of damaging hp", () => {
+    const world = new World();
+    const rng = createRng(2);
+    const h = spawnEnemy(world, "hexagon", rng);
+    world.get(h)!.pos = { x: 0, y: 0 };
+    const hpBefore = world.get(h)!.hp!.value;
+    explodeAt(world, 0, 0, 60, 99);
+    expect(world.get(h)!.hp!.value).toBe(hpBefore); // shield ate it
+    expect(world.get(h)!.enemy!.shield).toBe(0);
+  });
+
+  it("emits onEnemyKilled for each killed target", () => {
+    const world = new World();
+    const rng = createRng(3);
+    const id = spawnEnemy(world, "circle", rng);
+    world.get(id)!.pos = { x: 50, y: 50 };
+    const killed: number[] = [];
+    explodeAt(world, 50, 50, 20, 999, {
+      onEnemyKilled: (eid) => killed.push(eid),
+    });
+    expect(killed).toEqual([id]);
+  });
+});
+
+describe("Combustion drafting", () => {
+  it("spawnAvatar has no synergies until a card is applied", () => {
+    const world = new World();
+    const id = spawnAvatar(world);
+    expect(world.get(id)!.avatar!.synergies).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Fills the Synergy card slot from `axiom/docs/concept.md` (card pool now 14 → 18; Synergy 0 → 4)
- New `synergies.ts` owns runtime state, condition evaluation, and `explodeAt` helper; `Avatar.synergies` carries state so it survives and tests without touching PlayScene
- Condition-driven bonuses (Desperate / Kinetic / Stillness) are computed per-shot in `weapon.ts` and never mutate `WeaponState` — conditions can revert cleanly
- Combustion hooks the existing `onEnemyKilled` event bus (PR #16), with recursive dispatch so chain-kills inside the blast feed counters again
- `mirrorBoss.ts` mirrors each Synergy pick as flat boss stats (damage / hp / speed / fire rate)

## Cards
| id | Rarity | Effect |
|---|---|---|
| `combustion` | rare | Every 10 kills: radius-60 AoE for 2 damage around the avatar |
| `desperate`  | rare | While HP ≤ 2: ×2 damage |
| `kinetic`    | uncommon | While moving: +25% crit |
| `stillness`  | uncommon | While stationary: −25% fire interval |

## Test plan
- [x] `pnpm test` — 65 tests pass (10 new in `synergies.test.ts` + 1 new in `cards.test.ts`)
- [x] `pnpm build` — tsc + vite bundle succeed
- [ ] Manual dev run: draft `desperate`, take damage to HP ≤ 2, verify damage doubles; draft `stillness`, stop moving, verify faster fire
- [ ] CI green

https://claude.ai/code/session_01NWc7XktjPLh31bUeYLiLdh