### PR TITLE
Axiom: elite kills + draft token economy

### DIFF
--- a/axiom/index.html
+++ b/axiom/index.html
@@ -18,6 +18,7 @@
         <span id="hud-hp" class="hud-chip">HP: -</span>
         <span id="hud-wave" class="hud-chip">W: -/-</span>
         <span id="hud-pts" class="hud-chip">0pts</span>
+        <span id="hud-tokens" class="hud-chip" aria-label="draft tokens">⟐ 0</span>
         <span id="hud-seed" class="hud-chip" aria-label="run seed">seed: -</span>
         <button type="button" id="btn-mute" class="ctrl-btn ctrl-btn--mute" aria-label="Toggle sound">sfx on</button>
         <button type="button" id="btn-menu" class="ctrl-btn" aria-label="Main menu"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-0.125em"><line x1="4" y1="6" x2="20" y2="6"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="18" x2="20" y2="18"/></svg></button>

--- a/axiom/src/game/entities.ts
+++ b/axiom/src/game/entities.ts
@@ -68,6 +68,16 @@ const ENEMY_STATS: Record<EnemyKind, EnemyStats> = {
   crescent:  { hp: 5,  maxSpeed: 78,  contactDamage: 1, radius: 9 },
 };
 
+/** Kinds tagged as elite at spawn. Aligns with tier-2+ KILL_POINTS. */
+const ELITE_KINDS: ReadonlySet<EnemyKind> = new Set(["star", "pentagon", "hexagon", "cross"]);
+
+/** Per-kill HP multiplier applied to elite-marked spawns. */
+const ELITE_HP_MUL = 1.5;
+
+export function isEliteKind(kind: EnemyKind): boolean {
+  return ELITE_KINDS.has(kind);
+}
+
 export function spawnEnemy(world: World, kind: EnemyKind, rng: Rng): EntityId {
   const stats = ENEMY_STATS[kind];
   // Bosses appear in the upper play-field, centered. Other enemies spawn on
@@ -83,6 +93,7 @@ export function spawnEnemy(world: World, kind: EnemyKind, rng: Rng): EntityId {
     else if (edge === 2)   { x = rng() * PLAY_W; y = PLAY_H - ENEMY_SPAWN_MARGIN; }
     else                   { x = ENEMY_SPAWN_MARGIN; y = rng() * PLAY_H; }
   }
+  const elite = isEliteKind(kind);
   return world.create({
     pos: { x, y },
     vel: { x: 0, y: 0 },
@@ -98,8 +109,9 @@ export function spawnEnemy(world: World, kind: EnemyKind, rng: Rng): EntityId {
       dashCooldown: kind === "diamond" ? 2 + rng() * 2 : undefined,
       shootCooldown: kind === "cross" ? 1.5 + rng() : undefined,
       orbitAngle: kind === "crescent" ? rng() * Math.PI * 2 : undefined,
+      isElite: elite || undefined,
     },
-    hp: { value: stats.hp },
+    hp: { value: elite ? Math.ceil(stats.hp * ELITE_HP_MUL) : stats.hp },
   });
 }
 
@@ -109,6 +121,7 @@ export function spawnEnemyAt(world: World, kind: EnemyKind, rng: Rng, atX: numbe
   const spread = 12;
   const x = atX + (rng() - 0.5) * spread;
   const y = atY + (rng() - 0.5) * spread;
+  const elite = isEliteKind(kind);
   return world.create({
     pos: { x, y },
     vel: { x: 0, y: 0 },
@@ -123,8 +136,9 @@ export function spawnEnemyAt(world: World, kind: EnemyKind, rng: Rng, atX: numbe
       dashCooldown: kind === "diamond" ? 2 + rng() * 2 : undefined,
       shootCooldown: kind === "cross" ? 1.5 + rng() : undefined,
       orbitAngle: kind === "crescent" ? rng() * Math.PI * 2 : undefined,
+      isElite: elite || undefined,
     },
-    hp: { value: stats.hp },
+    hp: { value: elite ? Math.ceil(stats.hp * ELITE_HP_MUL) : stats.hp },
   });
 }
 

--- a/axiom/src/game/world.ts
+++ b/axiom/src/game/world.ts
@@ -60,6 +60,8 @@ export interface Enemy {
   burn?: { dps: number; remaining: number };
   /** Slow debuff applied by keyword effects. */
   slow?: { pct: number; remaining: number };
+  /** Marked as elite at spawn time. Elite kills yield +1 draft token. */
+  isElite?: boolean;
 }
 
 export type SynergyId = "combustion" | "desperate" | "kinetic" | "stillness";

--- a/axiom/src/main.ts
+++ b/axiom/src/main.ts
@@ -8,7 +8,7 @@ import { createRng, pickSeed } from "./game/rng";
 import { applyCard, drawOffer, type Card } from "./game/cards";
 import { DraftScene } from "./scenes/draft";
 import { EndgameScene } from "./scenes/endgame";
-import { PlayScene, type PointerMapper, type GameMode } from "./scenes/play";
+import { PlayScene, REROLL_TOKEN_COST, type PointerMapper, type GameMode } from "./scenes/play";
 import { SceneStack } from "./scenes/scene";
 import { MainMenuScene, type MenuAction } from "./scenes/mainMenu";
 import { StageSelectScene } from "./scenes/stageSelect";
@@ -49,6 +49,7 @@ async function boot(): Promise<void> {
   const hudHp = document.getElementById("hud-hp");
   const hudWave = document.getElementById("hud-wave");
   const hudPts = document.getElementById("hud-pts");
+  const hudTokens = document.getElementById("hud-tokens");
   const hudSeed = document.getElementById("hud-seed");
   const btnRestart = document.getElementById("btn-restart");
   const btnMute = document.getElementById("btn-mute");
@@ -117,10 +118,18 @@ async function boot(): Promise<void> {
 
   // ── HUD ─────────────────────────────────────────────────────────────────
 
-  function updateHud(hp: number, maxHp: number, waveIdx: number, totalWaves: number, points: number): void {
+  function updateHud(
+    hp: number,
+    maxHp: number,
+    waveIdx: number,
+    totalWaves: number,
+    points: number,
+    tokens: number,
+  ): void {
     if (hudHp) hudHp.textContent = `HP: ${hp}/${maxHp}`;
     if (hudWave) hudWave.textContent = `W: ${waveIdx}/${totalWaves}`;
     if (hudPts) hudPts.textContent = `${points}pts`;
+    if (hudTokens) hudTokens.textContent = `⟐ ${tokens}`;
   }
 
   const skillButtonUpdaters = new WeakMap<HTMLButtonElement, () => void>();
@@ -192,11 +201,27 @@ async function boot(): Promise<void> {
         updateHud,
         onWaveCleared: (cleared) => {
           playSfx("draft");
-          const offer = drawOffer(rng, 3);
           const label = mode === "survival"
             ? `${cleared}`
             : `${cleared} of ${play.totalWaves()}`;
-          stack.push(new DraftScene(offer, label, (pick) => onPickCard(pick)));
+          const offer = drawOffer(rng, 3);
+          let draft: DraftScene;
+          draft = new DraftScene(offer, label, {
+            onPick: (pick) => onPickCard(pick),
+            onReroll: () => {
+              if (play.draftTokens < REROLL_TOKEN_COST) return false;
+              play.draftTokens -= REROLL_TOKEN_COST;
+              draft.setOffer(drawOffer(rng, 3));
+              return true;
+            },
+            onSkip: () => {
+              stack.pop();
+              play.advanceToNextWave();
+            },
+            getTokens: () => play.draftTokens,
+            rerollCost: REROLL_TOKEN_COST,
+          });
+          stack.push(draft);
         },
         onPlayerDied: () => {
           playSfx("death");

--- a/axiom/src/render.ts
+++ b/axiom/src/render.ts
@@ -43,6 +43,12 @@ export function drawWorld(g: Graphics, world: World, theme?: StageTheme): void {
       g.circle(x, y, r + 3);
       g.stroke({ color: 0x00e5ff, width: 1.5 });
     }
+
+    // Elite ring — visual tell that this kill yields a draft token.
+    if (c.enemy!.isElite) {
+      g.circle(x, y, r + 5);
+      g.stroke({ color: 0xd81b60, width: 1.5 });
+    }
   }
 
   for (const [, c] of world.with("avatar", "pos", "radius")) {

--- a/axiom/src/scenes/draft.ts
+++ b/axiom/src/scenes/draft.ts
@@ -6,31 +6,73 @@ import { CARD_GLYPHS, setIconHtml } from "../icons";
 // Overlay-based scene — no Pixi drawing. Renders into `#overlay-inner` and
 // waits for a tap on one of the offered cards.
 
+export interface DraftHandlers {
+  onPick: (card: Card) => void;
+  /** Spend a token to redraw the offer. Returns true iff redraw happened. */
+  onReroll: () => boolean;
+  /** Leave without picking and without consuming a token. */
+  onSkip: () => void;
+  /** Current token balance, read each render. */
+  getTokens: () => number;
+  /** Cost of a reroll (for label rendering). */
+  rerollCost: number;
+}
+
 export class DraftScene implements Scene {
   readonly root: Container;
-  private readonly offer: readonly Card[];
-  private readonly onPick: (card: Card) => void;
+  private offer: readonly Card[];
+  private readonly handlers: DraftHandlers;
   private readonly clearedWaveLabel: string;
   private selected: Card | null = null;
 
-  constructor(offer: readonly Card[], clearedWaveLabel: string, onPick: (card: Card) => void) {
+  constructor(offer: readonly Card[], clearedWaveLabel: string, handlers: DraftHandlers) {
     this.root = new Container();
     this.offer = offer;
-    this.onPick = onPick;
+    this.handlers = handlers;
     this.clearedWaveLabel = clearedWaveLabel;
+  }
+
+  /** Replace the visible card offer (used by reroll). */
+  setOffer(next: readonly Card[]): void {
+    this.offer = next;
+    this.selected = null;
+    this.renderDom();
   }
 
   enter(): void {
     const overlay = document.getElementById("overlay");
-    const inner = document.getElementById("overlay-inner");
-    if (!overlay || !inner) return;
-    inner.innerHTML = "";
+    if (!overlay) return;
     this.selected = null;
+    this.renderDom();
+    overlay.hidden = false;
+  }
+
+  exit(): void {
+    const overlay = document.getElementById("overlay");
+    const inner = document.getElementById("overlay-inner");
+    if (inner) inner.innerHTML = "";
+    if (overlay) overlay.hidden = true;
+  }
+
+  update(_dt: number): void {}
+  // Pixi render hook is a no-op; this scene draws through DOM on enter/reroll.
+  render(_alpha: number): void {}
+
+  private renderDom(): void {
+    const inner = document.getElementById("overlay-inner");
+    if (!inner) return;
+    inner.innerHTML = "";
 
     const title = document.createElement("div");
     title.className = "overlay-title";
     title.textContent = `wave ${this.clearedWaveLabel} cleared — pick a rune`;
     inner.appendChild(title);
+
+    const tokens = this.handlers.getTokens();
+    const tokenRow = document.createElement("div");
+    tokenRow.className = "draft-tokens";
+    tokenRow.textContent = `tokens: ${tokens}`;
+    inner.appendChild(tokenRow);
 
     const list = document.createElement("div");
     list.className = "card-list";
@@ -85,21 +127,32 @@ export class DraftScene implements Scene {
     confirmBtn.disabled = true;
     confirmBtn.textContent = "pick a card first";
     confirmBtn.addEventListener("click", () => {
-      if (this.selected) this.onPick(this.selected);
+      if (this.selected) this.handlers.onPick(this.selected);
     });
     inner.appendChild(confirmBtn);
 
-    overlay.hidden = false;
+    const actionRow = document.createElement("div");
+    actionRow.className = "draft-actions";
+
+    const rerollBtn = document.createElement("button");
+    rerollBtn.type = "button";
+    rerollBtn.className = "secondary-btn";
+    rerollBtn.textContent = `reroll (${this.handlers.rerollCost})`;
+    rerollBtn.disabled = tokens < this.handlers.rerollCost;
+    rerollBtn.addEventListener("click", () => {
+      if (this.handlers.onReroll()) {
+        // setOffer re-renders; no further action here.
+      }
+    });
+
+    const skipBtn = document.createElement("button");
+    skipBtn.type = "button";
+    skipBtn.className = "secondary-btn";
+    skipBtn.textContent = "skip";
+    skipBtn.addEventListener("click", () => this.handlers.onSkip());
+
+    actionRow.appendChild(rerollBtn);
+    actionRow.appendChild(skipBtn);
+    inner.appendChild(actionRow);
   }
-
-  exit(): void {
-    const overlay = document.getElementById("overlay");
-    const inner = document.getElementById("overlay-inner");
-    if (inner) inner.innerHTML = "";
-    if (overlay) overlay.hidden = true;
-  }
-
-  update(_dt: number): void {}
-
-  render(_alpha: number): void {}
 }

--- a/axiom/src/scenes/play.ts
+++ b/axiom/src/scenes/play.ts
@@ -35,8 +35,13 @@ export interface PlayCallbacks {
   onPlayerDied: () => void;
   onRunWon: () => void;
   onRunComplete: (result: RunResult) => void;
-  updateHud: (hp: number, maxHp: number, waveIdx: number, totalWaves: number, points: number) => void;
+  updateHud: (hp: number, maxHp: number, waveIdx: number, totalWaves: number, points: number, tokens: number) => void;
 }
+
+/** Starting draft tokens per run; see concept.md § Resource model. */
+export const STARTING_DRAFT_TOKENS = 2;
+/** Token cost to reroll the current draft offer. */
+export const REROLL_TOKEN_COST = 1;
 
 // The canvas CSS size varies per viewport; map pointer events back to the
 // fixed 360×640 play-field so gameplay math stays resolution-independent.
@@ -72,6 +77,8 @@ export class PlayScene implements Scene {
   private runPoints = 0;
   private runKills = 0;
   private runBossKills = 0;
+  private runEliteKills = 0;
+  draftTokens = STARTING_DRAFT_TOKENS;
   private readonly loot: LootDrop[] = [];
   readonly stageIndex: number;
 
@@ -276,6 +283,9 @@ export class PlayScene implements Scene {
         this.cb.onRunComplete(this.buildRunResult());
         this.cb.onRunWon();
       } else {
+        // Wave clear grants a draft token, awarded before the draft screen
+        // opens so reroll is affordable on the very first draft.
+        this.draftTokens += 1;
         this.cb.onWaveCleared(cleared);
       }
     }
@@ -294,6 +304,11 @@ export class PlayScene implements Scene {
     const pts = KILL_POINTS[kind] ?? 1;
     this.runPoints += pts;
     this.runKills += 1;
+
+    if (ec.enemy.isElite) {
+      this.runEliteKills += 1;
+      this.draftTokens += 1;
+    }
 
     if (kind === "boss") {
       this.runBossKills += 1;
@@ -385,7 +400,7 @@ export class PlayScene implements Scene {
     const c = this.world.get(this.avatarId);
     const hp = c?.avatar?.hp ?? 0;
     const maxHp = c?.avatar?.maxHp ?? 0;
-    this.cb.updateHud(hp, maxHp, this.waveIdx + 1, this.totalWaves(), this.runPoints);
+    this.cb.updateHud(hp, maxHp, this.waveIdx + 1, this.totalWaves(), this.runPoints, this.draftTokens);
   }
 
   private onPointerDown(ev: PointerEvent): void {

--- a/axiom/src/style.css
+++ b/axiom/src/style.css
@@ -236,6 +236,45 @@ body {
   cursor: not-allowed;
 }
 
+/* ── Draft tokens & secondary actions ──────────────────────────────────── */
+
+.draft-tokens {
+  text-align: center;
+  font-size: 12px;
+  color: var(--muted);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.draft-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.secondary-btn {
+  appearance: none;
+  flex: 1 1 0;
+  padding: 10px 12px;
+  min-height: 44px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  background: #fff;
+  color: var(--fg);
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.secondary-btn:active {
+  background: var(--chrome);
+}
+
+.secondary-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 #footer-hint {
   flex: 0 0 auto;
   padding: 6px 12px calc(6px + env(safe-area-inset-bottom)) 12px;

--- a/axiom/tests/tokens.test.ts
+++ b/axiom/tests/tokens.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { isEliteKind, spawnEnemy } from "../src/game/entities";
+import { createRng } from "../src/game/rng";
+import { REROLL_TOKEN_COST, STARTING_DRAFT_TOKENS } from "../src/scenes/play";
+import { World, type EnemyKind } from "../src/game/world";
+
+describe("draft token constants", () => {
+  it("starting tokens and reroll cost match the concept", () => {
+    expect(STARTING_DRAFT_TOKENS).toBe(2);
+    expect(REROLL_TOKEN_COST).toBe(1);
+  });
+});
+
+describe("elite kind classification", () => {
+  it("flags tier-2+ kinds as elite", () => {
+    const elites: EnemyKind[] = ["star", "pentagon", "hexagon", "cross"];
+    for (const k of elites) expect(isEliteKind(k)).toBe(true);
+  });
+
+  it("leaves tier-1 / trivial kinds un-elite", () => {
+    const mundane: EnemyKind[] = ["circle", "square", "diamond", "crescent", "boss"];
+    for (const k of mundane) expect(isEliteKind(k)).toBe(false);
+  });
+});
+
+describe("spawnEnemy elite HP multiplier", () => {
+  it("applies 1.5× HP (ceiled) to elite-marked kinds", () => {
+    const world = new World();
+    const rng = createRng(1);
+    const id = spawnEnemy(world, "star", rng);
+    const e = world.get(id)!;
+    expect(e.enemy!.isElite).toBe(true);
+    // star base hp = 8 → ceil(8 * 1.5) = 12
+    expect(e.hp!.value).toBe(12);
+  });
+
+  it("leaves non-elite kinds untouched", () => {
+    const world = new World();
+    const rng = createRng(1);
+    const id = spawnEnemy(world, "circle", rng);
+    const e = world.get(id)!;
+    expect(e.enemy!.isElite).toBeUndefined();
+    expect(e.hp!.value).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- Draft tokens: start at **2**, +1 on elite kill, +1 on wave clear, reroll costs 1, skip is free.
- Elite marking: tier-2+ enemy kinds (`star` / `pentagon` / `hexagon` / `cross`) spawn with `isElite=true` and **×1.5 HP** (ceiled). A pink outer ring renders around elites so the reward is visible at a glance.
- Draft UI: overlay now shows a token chip, a dedicated reroll/skip action row, and disables reroll when the player is broke. Two-step commit (select → confirm) still prevents stray taps.
- HUD gets a new `⟐ N` chip for the live balance.

## Token flow (wave 5 example)
Player finishes wave 5 → `+1` token for clear → DraftScene opens with 3 cards and current token count → reroll spends 1 and redraws, or skip leaves no card applied.

## Test plan
- [x] `pnpm build` (tsc + vite) green
- [x] `pnpm test` all 70 tests pass, including new `tests/tokens.test.ts` (starting balance, reroll cost, elite classification, elite HP multiplier)
- [x] existing suites (cards / keywords / synergies / wave / rewards) unchanged
- [ ] manual dev-server pass: verify elite ring renders, reroll decrements token, skip advances wave without applying

https://claude.ai/code/session_01NWc7XktjPLh31bUeYLiLdh