### PR TITLE
Axiom: boss skill ground telegraph

### DIFF
--- a/axiom/ROADMAP.md
+++ b/axiom/ROADMAP.md
@@ -6,8 +6,8 @@
 ## P0 — 對齊 concept.md MVP 缺口
 
 ### 戰鬥系統
-- [ ] **Boss 技能地面預警線**（技能釋放前 ~0.8 秒畫出警告區；concept § 偏離表明訂）
-- [ ] **Elite 標記 + 擊殺 +1 draft token**（補齊 token 經濟：起始 2、elite / wave clear +1）
+- [x] **Boss 技能地面預警線**（技能釋放前 ~0.8 秒畫出警告區；concept § 偏離表明訂）
+- [x] **Elite 標記 + 擊殺 +1 draft token**（補齊 token 經濟：起始 2、elite / wave clear +1）
 - [x] **Pentagon splitter** 行為：擊殺後分裂成 2–3 個小圓形敵人
 
 ### 關鍵字系統

--- a/axiom/src/game/systems/bossWeapon.ts
+++ b/axiom/src/game/systems/bossWeapon.ts
@@ -2,7 +2,13 @@ import { spawnEnemyShot } from "../entities";
 import type { Rng } from "../rng";
 import type { EntityId, World } from "../world";
 
-const FAN_SPREAD = 0.22;
+/** Fan half-spread (radians) between adjacent projectiles. */
+export const BOSS_FAN_SPREAD = 0.22;
+/**
+ * Seconds of lead time between the telegraph appearing and the actual shot.
+ * Matches concept.md § "偏離表" — boss skills must be readable before firing.
+ */
+export const BOSS_TELEGRAPH_LEAD = 0.8;
 
 export function updateBossWeapon(
   world: World,
@@ -20,15 +26,25 @@ export function updateBossWeapon(
     if (c.hp!.value <= 0) continue;
     const w = c.weapon!;
     w.cooldown -= dt;
+
+    // Snapshot the aim once the lead window opens. The render layer keys off
+    // telegraphAngle to draw the warning arc; locking the angle here means
+    // the player's dodge target matches the drawn warning, not the boss's
+    // current tracking.
+    if (w.cooldown <= BOSS_TELEGRAPH_LEAD && c.enemy!.telegraphAngle === undefined) {
+      c.enemy!.telegraphAngle = Math.atan2(ay - c.pos!.y, ax - c.pos!.x);
+    }
+
     if (w.cooldown > 0) continue;
 
-    const dx = ax - c.pos!.x;
-    const dy = ay - c.pos!.y;
-    const baseAngle = Math.atan2(dy, dx);
+    const baseAngle =
+      c.enemy!.telegraphAngle ?? Math.atan2(ay - c.pos!.y, ax - c.pos!.x);
+    c.enemy!.telegraphAngle = undefined;
+
     const n = Math.max(1, w.projectiles);
-    const startAngle = baseAngle - FAN_SPREAD * (n - 1) / 2;
+    const startAngle = baseAngle - (BOSS_FAN_SPREAD * (n - 1)) / 2;
     for (let i = 0; i < n; i++) {
-      const a = startAngle + FAN_SPREAD * i;
+      const a = startAngle + BOSS_FAN_SPREAD * i;
       const vx = Math.cos(a) * w.projectileSpeed;
       const vy = Math.sin(a) * w.projectileSpeed;
       const crit = rng() < w.crit;

--- a/axiom/src/game/world.ts
+++ b/axiom/src/game/world.ts
@@ -62,6 +62,12 @@ export interface Enemy {
   slow?: { pct: number; remaining: number };
   /** Marked as elite at spawn time. Elite kills yield +1 draft token. */
   isElite?: boolean;
+  /**
+   * Boss telegraph aim snapshotted at the start of the lead window.
+   * Locked so the player can dodge from the warning they see, not from
+   * where the boss is currently tracking. Cleared when the shot fires.
+   */
+  telegraphAngle?: number;
 }
 
 export type SynergyId = "combustion" | "desperate" | "kinetic" | "stillness";

--- a/axiom/src/render.ts
+++ b/axiom/src/render.ts
@@ -1,5 +1,6 @@
 import { Graphics } from "pixi.js";
 import { PLAY_H, PLAY_W } from "./game/config";
+import { BOSS_FAN_SPREAD, BOSS_TELEGRAPH_LEAD } from "./game/systems/bossWeapon";
 import type { EnemyKind, World } from "./game/world";
 import type { StageTheme } from "./game/stageThemes";
 
@@ -27,6 +28,26 @@ export function drawWorld(g: Graphics, world: World, theme?: StageTheme): void {
       g.circle(c.pos!.x, c.pos!.y, c.radius! + 1.5);
       g.stroke({ color: strokeColor, width: 1 });
     }
+  }
+
+  // Boss telegraph: draw each pending fan ray before enemies so the boss
+  // body overlaps the origin. Alpha ramps up as the shot nears.
+  const RAY_LEN = Math.hypot(PLAY_W, PLAY_H);
+  for (const [, c] of world.with("enemy", "weapon", "pos")) {
+    if (c.enemy!.kind !== "boss") continue;
+    const ang = c.enemy!.telegraphAngle;
+    if (ang === undefined) continue;
+    const remaining = c.weapon!.cooldown;
+    const t = 1 - Math.max(0, Math.min(1, remaining / BOSS_TELEGRAPH_LEAD));
+    const alpha = 0.2 + 0.55 * t;
+    const n = Math.max(1, c.weapon!.projectiles);
+    const startAngle = ang - (BOSS_FAN_SPREAD * (n - 1)) / 2;
+    for (let i = 0; i < n; i++) {
+      const a = startAngle + BOSS_FAN_SPREAD * i;
+      g.moveTo(c.pos!.x, c.pos!.y);
+      g.lineTo(c.pos!.x + Math.cos(a) * RAY_LEN, c.pos!.y + Math.sin(a) * RAY_LEN);
+    }
+    g.stroke({ color: 0xff2020, alpha, width: 2 });
   }
 
   for (const [, c] of world.with("enemy", "pos", "radius")) {

--- a/axiom/tests/bossTelegraph.test.ts
+++ b/axiom/tests/bossTelegraph.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+
+import { BOSS_TELEGRAPH_LEAD, updateBossWeapon } from "../src/game/systems/bossWeapon";
+import { createRng } from "../src/game/rng";
+import { World, type WeaponState } from "../src/game/world";
+
+function makeBossWeapon(partial: Partial<WeaponState> = {}): WeaponState {
+  return {
+    period: 1.1,
+    damage: 1,
+    projectileSpeed: 200,
+    projectiles: 1,
+    pierce: 0,
+    crit: 0,
+    cooldown: 1.0,
+    ricochet: 0,
+    chain: 0,
+    burnDps: 0,
+    burnDuration: 0,
+    slowPct: 0,
+    slowDuration: 0,
+    ...partial,
+  };
+}
+
+function spawnAvatarAt(world: World, x: number, y: number) {
+  return world.create({
+    pos: { x, y },
+    radius: 10,
+    team: "player",
+    avatar: { hp: 3, maxHp: 3, speedMul: 1, iframes: 0, targetX: x, targetY: y },
+  });
+}
+
+function spawnBossAt(world: World, x: number, y: number, weapon: WeaponState) {
+  return world.create({
+    pos: { x, y },
+    vel: { x: 0, y: 0 },
+    radius: 22,
+    team: "enemy",
+    enemy: { kind: "boss", contactDamage: 1, maxSpeed: 52, wobblePhase: 0 },
+    hp: { value: 60 },
+    weapon,
+  });
+}
+
+describe("boss telegraph", () => {
+  it("snapshots aim once cooldown enters the lead window", () => {
+    const world = new World();
+    const rng = createRng(1);
+    const aId = spawnAvatarAt(world, 100, 100);
+    const bId = spawnBossAt(world, 100, 0, makeBossWeapon({ cooldown: 1.0 }));
+
+    // Cooldown 1.0 → 0.95: still above the 0.8s lead, no telegraph yet.
+    updateBossWeapon(world, aId, rng, 0.05);
+    expect(world.get(bId)!.enemy!.telegraphAngle).toBeUndefined();
+
+    // Crossing into the lead window locks in the aim.
+    updateBossWeapon(world, aId, rng, 0.2);
+    const snapped = world.get(bId)!.enemy!.telegraphAngle;
+    expect(snapped).toBeDefined();
+    // Avatar is directly below boss (dy = 100, dx = 0) → angle = π/2.
+    expect(snapped!).toBeCloseTo(Math.PI / 2, 5);
+  });
+
+  it("does not re-aim mid-telegraph when the avatar moves", () => {
+    const world = new World();
+    const rng = createRng(1);
+    const aId = spawnAvatarAt(world, 100, 100);
+    const bId = spawnBossAt(world, 100, 0, makeBossWeapon({ cooldown: 0.5 }));
+
+    updateBossWeapon(world, aId, rng, 0.01);
+    const snapped = world.get(bId)!.enemy!.telegraphAngle;
+    expect(snapped).toBeCloseTo(Math.PI / 2, 5);
+
+    // Teleport avatar hard left while the boss is still winding up.
+    world.get(aId)!.pos!.x = -200;
+    world.get(aId)!.pos!.y = 0;
+
+    updateBossWeapon(world, aId, rng, 0.1);
+    // Stored aim must stay glued to where the warning was drawn.
+    expect(world.get(bId)!.enemy!.telegraphAngle).toBeCloseTo(snapped!, 5);
+  });
+
+  it("fires toward the snapshotted aim, not the avatar's current pos", () => {
+    const world = new World();
+    const rng = createRng(1);
+    const aId = spawnAvatarAt(world, 100, 100);
+    const bId = spawnBossAt(world, 100, 0, makeBossWeapon({ cooldown: 0.5 }));
+
+    updateBossWeapon(world, aId, rng, 0.01);
+    expect(world.get(bId)!.enemy!.telegraphAngle).toBeCloseTo(Math.PI / 2, 5);
+
+    // Fake the player dodging during the warning.
+    world.get(aId)!.pos!.x = 999;
+    world.get(aId)!.pos!.y = -999;
+
+    // Tick past cooldown so the shot fires.
+    updateBossWeapon(world, aId, rng, 0.6);
+
+    // Cooldown reset and telegraph cleared.
+    expect(world.get(bId)!.weapon!.cooldown).toBeCloseTo(1.1, 5);
+    expect(world.get(bId)!.enemy!.telegraphAngle).toBeUndefined();
+
+    // Exactly one enemy-shot fired, aimed downward (along the snapshot).
+    let count = 0;
+    let vx = 0;
+    let vy = 0;
+    for (const [, c] of world.with("projectile", "vel")) {
+      if (c.team !== "enemy-shot") continue;
+      count += 1;
+      vx = c.vel!.x;
+      vy = c.vel!.y;
+    }
+    expect(count).toBe(1);
+    expect(vx).toBeCloseTo(0, 4);
+    expect(vy).toBeCloseTo(200, 4);
+  });
+
+  it("exposes a lead time within concept.md's ~0.8s window", () => {
+    // Sanity check: tying the constant to tests guards the concept spec.
+    expect(BOSS_TELEGRAPH_LEAD).toBeGreaterThan(0.5);
+    expect(BOSS_TELEGRAPH_LEAD).toBeLessThan(1.2);
+  });
+});


### PR DESCRIPTION
## Summary
Boss fan shots now telegraph ~0.8s before they fire, per `concept.md § 偏離表`. When the boss's cooldown drops into the lead window it **locks the aim angle**, the renderer draws red fan rays along each projectile's intended path (alpha ramping toward fire), and the shot spawns using that snapshotted angle — not live tracking — so the warning the player sees is the warning that fires.

## Why lock the angle?
If the aim kept tracking the avatar during the 0.8s wind-up, the telegraph would be a lie: the player would dodge the drawn rays but get hit anyway. Locking at snapshot time makes the dodge honest.

## Files
- `src/game/world.ts` — `Enemy.telegraphAngle?: number`
- `src/game/systems/bossWeapon.ts` — exports `BOSS_TELEGRAPH_LEAD = 0.8`, snapshots on entering lead window, fires from snapshot, clears on fire
- `src/render.ts` — fan rays with alpha `0.2 + 0.55 · t` (t = 0 at start, 1 at fire)
- `tests/bossTelegraph.test.ts` — 4 cases: window entry, aim lock under avatar motion, fires-from-snapshot even after player dodge, constant sanity
- `ROADMAP.md` — tick boss telegraph + elite tokens (PR #24 shipped but missed the roadmap tick commit)

## Test plan
- [x] `pnpm test` 74/74 pass (4 new)
- [x] `pnpm build` green
- [ ] manual: reach wave 8, watch the boss draw rays before each fan, confirm dodging the rays dodges the shots

https://claude.ai/code/session_01NWc7XktjPLh31bUeYLiLdh