### PR TITLE
Axiom: extract draft token constants to pixi-free config

### DIFF
--- a/axiom/src/game/config.ts
+++ b/axiom/src/game/config.ts
@@ -31,3 +31,7 @@ export const MAX_FRAME = 0.1;
 
 // Hit flash (seconds)
 export const HIT_FLASH_TIME = 0.1;
+
+// Draft token economy (concept.md § Resource model).
+export const STARTING_DRAFT_TOKENS = 2;
+export const REROLL_TOKEN_COST = 1;

--- a/axiom/src/main.ts
+++ b/axiom/src/main.ts
@@ -2,13 +2,13 @@ import "./style.css";
 import { Application } from "pixi.js";
 
 import { isMuted, playSfx, primeSfx, setMuted } from "./game/audio";
-import { PLAY_H, PLAY_W } from "./game/config";
+import { PLAY_H, PLAY_W, REROLL_TOKEN_COST } from "./game/config";
 import { startLoop } from "./game/loop";
 import { createRng, pickSeed } from "./game/rng";
 import { applyCard, drawOffer, type Card } from "./game/cards";
 import { DraftScene } from "./scenes/draft";
 import { EndgameScene } from "./scenes/endgame";
-import { PlayScene, REROLL_TOKEN_COST, type PointerMapper, type GameMode } from "./scenes/play";
+import { PlayScene, type PointerMapper, type GameMode } from "./scenes/play";
 import { SceneStack } from "./scenes/scene";
 import { MainMenuScene, type MenuAction } from "./scenes/mainMenu";
 import { StageSelectScene } from "./scenes/stageSelect";

--- a/axiom/src/scenes/play.ts
+++ b/axiom/src/scenes/play.ts
@@ -2,6 +2,7 @@ import { Container, Graphics } from "pixi.js";
 
 import { playSfx } from "../game/audio";
 import type { Card } from "../game/cards";
+import { STARTING_DRAFT_TOKENS } from "../game/config";
 import { spawnAvatar } from "../game/entities";
 import { applyMirrorSpec, mirrorBossSpec } from "../game/mirrorBoss";
 import type { Rng } from "../game/rng";
@@ -37,11 +38,6 @@ export interface PlayCallbacks {
   onRunComplete: (result: RunResult) => void;
   updateHud: (hp: number, maxHp: number, waveIdx: number, totalWaves: number, points: number, tokens: number) => void;
 }
-
-/** Starting draft tokens per run; see concept.md § Resource model. */
-export const STARTING_DRAFT_TOKENS = 2;
-/** Token cost to reroll the current draft offer. */
-export const REROLL_TOKEN_COST = 1;
 
 // The canvas CSS size varies per viewport; map pointer events back to the
 // fixed 360×640 play-field so gameplay math stays resolution-independent.

--- a/axiom/tests/tokens.test.ts
+++ b/axiom/tests/tokens.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 
+import { REROLL_TOKEN_COST, STARTING_DRAFT_TOKENS } from "../src/game/config";
 import { isEliteKind, spawnEnemy } from "../src/game/entities";
 import { createRng } from "../src/game/rng";
-import { REROLL_TOKEN_COST, STARTING_DRAFT_TOKENS } from "../src/scenes/play";
 import { World, type EnemyKind } from "../src/game/world";
 
 describe("draft token constants", () => {


### PR DESCRIPTION
## Summary

Fix CI failure on `main` introduced by PR #24 (elite + draft token economy).

`tests/tokens.test.ts` imported `STARTING_DRAFT_TOKENS` / `REROLL_TOKEN_COST` from `src/scenes/play.ts`, which transitively pulls in `pixi.js`. Pixi's `BrowserAdapter` evaluates `navigator` at module load, which is undefined in vitest's default Node env → `ReferenceError: navigator is not defined`.

## Fix

Move both constants to `src/game/config.ts` (pixi-free). Update imports in `main.ts`, `play.ts`, and `tokens.test.ts`.

## Test plan

- [x] `pnpm test` — 70 tests passing (was red on CI for tokens.test.ts)
- [x] `pnpm build` — green
- [x] `pnpm typecheck` — no errors

https://claude.ai/code/session_01NWc7XktjPLh31bUeYLiLdh